### PR TITLE
Fixed Examples

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -31,7 +31,7 @@
 //      if err != nil {
 //          return
 //      }
-//      if _, err := conn.WriteMessaage(messageType, p); err != nil {
+//      if err = conn.WriteMessage(messageType, p); err != nil {
 //          return err
 //      }
 //  }


### PR DESCRIPTION
- Typo ("conn.WriteMessaage" should be "conn.WriteMessage")
- Fixed Incorrect WriteMessage call:
  
  func (c *Conn) WriteMessage(messageType int, data []byte) error

But the example uses `_, err` when there is only 1 return type.
