### PR TITLE
Add WriteText method

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -493,6 +493,12 @@ func (c *Conn) WriteMessage(messageType int, data []byte) error {
 	return nil
 }
 
+// WriteText writes given string with messageType TextMessage
+// Is actually a shorthand for (*Conn).WriteMessage(websocket.TextMessage, []byte(message))
+func (c *Conn) WriteText(message string) error {
+	return c.WriteMessage(TextMessage, []byte(message))
+}
+
 // SetWriteDeadline sets the deadline for future calls to NextWriter and the
 // io.WriteCloser returned from NextWriter. If the deadline is reached, the
 // call will fail with a timeout instead of blocking. A zero value for t means


### PR DESCRIPTION
I've made this shorthand for writing text. I find it very useful for "plain-text" protocols/communication and I believe it to be a good addition for the package. 

I'm also thinking about the Read equivalent.
For instance `msgString, err = conn.ReadText()` where a non-TextMessage read will result in an error.
It's a bit more aggressive because of the required type, but then, users require the type anyway..
Maybe add an ErrWrongMessageType to return when the type for the read message is not TextMessage.
