### PR TITLE
Changing a swap in README.md for autobahn

### DIFF
--- a/examples/autobahn/README.md
+++ b/examples/autobahn/README.md
@@ -10,4 +10,4 @@ and start the client test driver
 
     wstest -m fuzzingclient -s fuzzingclient.json
 
-When the client completes, it writes a report to reports/servers/index.html.
+When the client completes, it writes a report to reports/clients/index.html.


### PR DESCRIPTION
Autobahn test suite configuration fuzzingclient.json refers to 'clients' folder, but README.md refers to server. I changed README.md to clients, although I can't figure a good way to choose between changing README.md for 'clients' or fuzzingclient.json for servers. both seems legit to me, depending on what side you see things. Feel free to dismiss/decline my PR if you think the former makes more sense in this context.
