### PR TITLE
Forgot an error check.

### DIFF
--- a/server.go
+++ b/server.go
@@ -137,6 +137,9 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	}
 	var rw *bufio.ReadWriter
 	netConn, rw, err = h.Hijack()
+	if (err!=nil) {
+		return nil, err;
+	}
 	br = rw.Reader
 
 	if br.Buffered() > 0 {


### PR DESCRIPTION
I was trying to use ServeHTTP to directly negotiate a websocket connection without
having to use an actual network connection (i.e., using a `httptest.ResponseRecorder`).
Doing so, I managed to trigger an error here but it wasn't checked which resulted
in a panic later.
