### PR TITLE
docs: Specify arguments to P(i|o)ngHandler

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -789,6 +789,7 @@ func (c *Conn) SetReadLimit(limit int64) {
 }
 
 // SetPingHandler sets the handler for ping messages received from the peer.
+// It's argument is the payload or "Application data" of that very message.
 // The default ping handler sends a pong to the peer.
 func (c *Conn) SetPingHandler(h func(string) error) {
 	if h == nil {
@@ -801,6 +802,7 @@ func (c *Conn) SetPingHandler(h func(string) error) {
 }
 
 // SetPongHandler sets the handler for pong messages received from the peer.
+// It's argument is the payload or "Application data" of that very message.
 // The default pong handler does nothing.
 func (c *Conn) SetPongHandler(h func(string) error) {
 	if h == nil {


### PR DESCRIPTION
Previously, the parameters to the ping and pong handlers were not documented. They are the payload of the ping and pong messages respectively.

In RFC 6455 this is referred to as "Application data".

See:
 * [Ping, Section 5.5.2](https://tools.ietf.org/html/rfc6455#section-5.5.2)
 * [Pong, Section 5.5.3](https://tools.ietf.org/html/rfc6455#section-5.5.3)