### PR TITLE
Fix to remove possible race condition with initialisation of Dialer.

### DIFF
--- a/client.go
+++ b/client.go
@@ -154,7 +154,7 @@ func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
 }
 
 // DefaultDialer is a dialer with all fields set to the default zero values.
-var DefaultDialer *Dialer
+var DefaultDialer = &Dialer{}
 
 // Dial creates a new client connection. Use requestHeader to specify the
 // origin (Origin), subprotocols (Sec-WebSocket-Protocol) and cookies (Cookie).


### PR DESCRIPTION
Moved the initialisation of the `Dialer` to the declaration of `DefaultDialer` to avoid possible race condition.

Credit goes to @davecheney for spotting the issue. 