### PR TITLE
chat example revised to use single goroutine per connection

### DIFF
--- a/examples/chat/home.html
+++ b/examples/chat/home.html
@@ -26,13 +26,14 @@
         if (!msg.val()) {
             return false;
         }
-        conn.send(msg.val());
+
+        conn.send( JSON.stringify({ chan: "{{ .BcPrefix }}", msg: msg.val() }) );
         msg.val("");
         return false
     });
 
     if (window["WebSocket"]) {
-        conn = new WebSocket("ws://{{$}}/ws");
+        conn = new WebSocket("ws://{{ .Hostname }}/ws");
         conn.onclose = function(evt) {
             appendLog($("<div><b>Connection closed.</b></div>"))
         }

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -24,14 +24,23 @@ func serveHome(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	homeTempl.Execute(w, r.Host)
+
+	homeTempl.Execute(w, struct {
+		BcPrefix string
+		Hostname string
+	}{BcPrefix: BcPrefix, Hostname: r.Host})
 }
 
 func main() {
+
 	flag.Parse()
+
 	go h.run()
+
 	http.HandleFunc("/", serveHome)
+
 	http.HandleFunc("/ws", serveWs)
+
 	err := http.ListenAndServe(*addr, nil)
 	if err != nil {
 		log.Fatal("ListenAndServe: ", err)


### PR DESCRIPTION
The chat example seems to allow multiple goroutines reading from connections in an unsafe way.  This example does one goroutine per connection.