### PR TITLE
Allow cross-origin requests for example

### DIFF
--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -20,7 +20,8 @@ var upgrader = websocket.Upgrader{
 	CheckOrigin: func(r *http.Request) bool {
         return true
     },
-} // use default options, except origin. Allows cross-origin requests for testing.
+} /* use default options, except origin. Allows cross-origin requests for testing. 
+Presents a security risk if run in production */
 
 func echo(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {

--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -16,7 +16,11 @@ import (
 
 var addr = flag.String("addr", "localhost:8081", "http service address")
 
-var upgrader = websocket.Upgrader{} // use default options
+var upgrader = websocket.Upgrader{
+	CheckOrigin: func(r *http.Request) bool {
+        return true
+    },
+} // use default options, except origin. Allows cross-origin requests for testing.
 
 func echo(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {


### PR DESCRIPTION
For the sake of testing the websocket server, accepting cross-origin requests is useful - to allow usage of things like http://www.websocket.org/echo.html