### PR TITLE
Add support for fasthttp

### DIFF
--- a/fasthttp.go
+++ b/fasthttp.go
@@ -1,0 +1,116 @@
+// +build go1.4
+
+package websocket
+
+import (
+	"bytes"
+	"net"
+
+	"github.com/valyala/fasthttp"
+)
+
+func checkSameOriginFastHTTP(ctx *fasthttp.RequestCtx) bool {
+	return checkSameOriginFromHeaderAndHost(string(ctx.Request.Header.Peek(originHeader)), string(ctx.Host()))
+}
+
+// FastHTTPUpgrader is used to upgrade a fasthttp request into a websocket
+// connection. A Handler function must be provided to receive that connection.
+type FastHTTPUpgrader struct {
+	// Handler receives a websocket connection after the handshake has been
+	// completed. This must be provided.
+	Handler func(*Conn)
+
+	// ReadBufferSize and WriteBufferSize specify I/O buffer sizes. If a buffer
+	// size is zero, then a default value of 4096 is used. The I/O buffer sizes
+	// do not limit the size of the messages that can be sent or received.
+	ReadBufferSize, WriteBufferSize int
+
+	// Subprotocols specifies the server's supported protocols in order of
+	// preference. If this field is set, then the Upgrade method negotiates a
+	// subprotocol by selecting the first match in this list with a protocol
+	// requested by the client.
+	Subprotocols []string
+
+	// CheckOrigin returns true if the request Origin header is acceptable. If
+	// CheckOrigin is nil, the host in the Origin header must not be set or
+	// must match the host of the request.
+	CheckOrigin func(ctx *fasthttp.RequestCtx) bool
+}
+
+var websocketVersionByte = []byte(websocketVersion)
+
+// UpgradeHandler handles a request for a websocket connection and does all the
+// checks necessary to ensure the request is valid. If a CheckOrigin function
+// was provided, it will be called, otherwise the Origin will be checked against
+// the request host value. If a subprotocol has not already been set, the best
+// choice will be made from the values provided to the upgrader and from the
+// client.
+//
+// Once the request has been verified and the response sent, the connection will
+// be hijacked and the provided Handler will be called.
+func (f *FastHTTPUpgrader) UpgradeHandler(ctx *fasthttp.RequestCtx) {
+	if f.Handler == nil {
+		panic("FastHTTPUpgrader does not have a Handler set")
+	}
+
+	if !ctx.IsGet() {
+		ctx.Error("websocket: method not GET", fasthttp.StatusMethodNotAllowed)
+		return
+	}
+
+	if !bytes.Equal(ctx.Request.Header.Peek("Sec-Websocket-Version"), websocketVersionByte) {
+		ctx.Error("websocket: version != 13", fasthttp.StatusBadRequest)
+		return
+	}
+
+	if !ctx.Request.Header.ConnectionUpgrade() {
+		ctx.Error("websocket: could not find connection header with token 'upgrade'", fasthttp.StatusBadRequest)
+		return
+	}
+
+	if !tokenListContainsValue(string(ctx.Request.Header.Peek("Upgrade")), "websocket") {
+		ctx.Error("websocket: could not find upgrade header with token 'websocket'", fasthttp.StatusBadRequest)
+		return
+	}
+
+	checkOrigin := f.CheckOrigin
+	if checkOrigin == nil {
+		checkOrigin = checkSameOriginFastHTTP
+	}
+	if !checkOrigin(ctx) {
+		ctx.Error("websocket: origin not allowed", fasthttp.StatusForbidden)
+		return
+	}
+
+	challengeKey := ctx.Request.Header.Peek("Sec-Websocket-Key")
+	if len(challengeKey) == 0 {
+		ctx.Error("websocket: key missing or blank", fasthttp.StatusBadRequest)
+		return
+	}
+
+	ctx.SetStatusCode(fasthttp.StatusSwitchingProtocols)
+	ctx.Response.Header.Set("Upgrade", "websocket")
+	ctx.Response.Header.Set("Connection", "Upgrade")
+	ctx.Response.Header.Set("Sec-WebSocket-Accept", computeAcceptKeyByte(challengeKey))
+
+	// The subprotocol may have already been set in the response
+	subprotocol := string(ctx.Response.Header.Peek(protocolHeader))
+	if subprotocol == "" {
+		// Find the best protocol, if any
+		clientProtocols := subprotocolsFromHeader(string(ctx.Request.Header.Peek(protocolHeader)))
+		if len(clientProtocols) != 0 {
+			subprotocol = matchSubprotocol(clientProtocols, f.Subprotocols)
+			if subprotocol != "" {
+				ctx.Response.Header.Set(protocolHeader, subprotocol)
+			}
+		}
+	}
+
+	ctx.Hijack(func(conn net.Conn) {
+		c := newConn(conn, true, f.ReadBufferSize, f.WriteBufferSize)
+		if subprotocol != "" {
+			c.subprotocol = subprotocol
+		}
+		f.Handler(c)
+	})
+}

--- a/util.go
+++ b/util.go
@@ -13,14 +13,19 @@ import (
 	"strings"
 )
 
-// tokenListContainsValue returns true if the 1#token header with the given
+// headerListContainsValue returns true if the 1#token header with the given
 // name contains token.
-func tokenListContainsValue(header http.Header, name string, value string) bool {
+func headerListContainsValue(header http.Header, name string, value string) bool {
 	for _, v := range header[name] {
-		for _, s := range strings.Split(v, ",") {
-			if strings.EqualFold(value, strings.TrimSpace(s)) {
-				return true
-			}
+		return tokenListContainsValue(v, value)
+	}
+	return false
+}
+
+func tokenListContainsValue(list string, value string) bool {
+	for _, s := range strings.Split(list, ",") {
+		if strings.EqualFold(value, strings.TrimSpace(s)) {
+			return true
 		}
 	}
 	return false
@@ -29,8 +34,12 @@ func tokenListContainsValue(header http.Header, name string, value string) bool 
 var keyGUID = []byte("258EAFA5-E914-47DA-95CA-C5AB0DC85B11")
 
 func computeAcceptKey(challengeKey string) string {
+	return computeAcceptKeyByte([]byte(challengeKey))
+}
+
+func computeAcceptKeyByte(challengeKey []byte) string {
 	h := sha1.New()
-	h.Write([]byte(challengeKey))
+	h.Write(challengeKey)
 	h.Write(keyGUID)
 	return base64.StdEncoding.EncodeToString(h.Sum(nil))
 }

--- a/util_test.go
+++ b/util_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 )
 
-var tokenListContainsValueTests = []struct {
+var headerListContainsValueTests = []struct {
 	value string
 	ok    bool
 }{
@@ -23,12 +23,12 @@ var tokenListContainsValueTests = []struct {
 	{"other, websocket, more", true},
 }
 
-func TestTokenListContainsValue(t *testing.T) {
-	for _, tt := range tokenListContainsValueTests {
+func TestHeaderListContainsValue(t *testing.T) {
+	for _, tt := range headerListContainsValueTests {
 		h := http.Header{"Upgrade": {tt.value}}
-		ok := tokenListContainsValue(h, "Upgrade", "websocket")
+		ok := headerListContainsValue(h, "Upgrade", "websocket")
 		if ok != tt.ok {
-			t.Errorf("tokenListContainsValue(h, n, %q) = %v, want %v", tt.value, ok, tt.ok)
+			t.Errorf("headerListContainsValue(h, n, %q) = %v, want %v", tt.value, ok, tt.ok)
 		}
 	}
 }


### PR DESCRIPTION
So this is a bit of a "speculative" PR in that I don't know if you guys are open to this kind of contribution and also whether the way I have written it matches the rest of the project.

The basic idea is I need websocket support in a project which uses the relatively new Go HTTP package [fasthttp](https://github.com/valyala/fasthttp).

Gorilla websocket seemed like the best option to add this.

As you can see in the diff I have refactored various non-exported utility functions to make them usable from both `net/http` and `fasthttp` code, and then I added a `FastHTTPUpgrader`. The way fasthttp does hijacking is quite a bit different (and better IMO) than `net/http`, so the `FastHTTPUpgrader .UpgradeHandler()` is quite a bit more sane than the one for the standard `Upgrader.Upgrade()`.

The existing tests pass but I did not add any tests for my addition. I could do that but didn't want to spend the time if this PR would be rejected.