### PR TITLE
fix case sensitive header check

### DIFF
--- a/server.go
+++ b/server.go
@@ -96,7 +96,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	if r.Method != "GET" {
 		return u.returnError(w, r, http.StatusMethodNotAllowed, "websocket: method not GET")
 	}
-	if values := r.Header["Sec-Websocket-Version"]; len(values) == 0 || values[0] != "13" {
+	if values := r.Header.Get("Sec-Websocket-Version"); len(values) == 0 || values != "13" {
 		return u.returnError(w, r, http.StatusBadRequest, "websocket: version != 13")
 	}
 


### PR DESCRIPTION
The upgrader is checking the `Sec-Websocket-Version` in a case sensitive way directly against the header map. This means, if someone sends the correct header as specified by [RFC 6455](https://tools.ietf.org/html/rfc6455#section-11.3.5) the code fails. The fix checks the header with the canonical formats.

This should fix #101 