### PR TITLE
Close Frame Response

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -726,13 +726,15 @@ func (c *Conn) advanceFrame() (int, error) {
 			return noFrame, err
 		}
 	case CloseMessage:
-		c.WriteControl(CloseMessage, []byte{}, time.Now().Add(writeWait))
+		echoMessage := []byte{}
 		closeCode := CloseNoStatusReceived
 		closeText := ""
 		if len(payload) >= 2 {
+			echoMessage = payload[:2]
 			closeCode = int(binary.BigEndian.Uint16(payload))
 			closeText = string(payload[2:])
 		}
+		c.WriteControl(CloseMessage,  echoMessage, time.Now().Add(writeWait))
 		return noFrame, &CloseError{Code: closeCode, Text: closeText}
 	}
 


### PR DESCRIPTION
Taking a look at the documentation of the [Close Frame](https://tools.ietf.org/html/rfc6455#section-5.5.1) in the WebSocket RFC it mentions the following:

> When sending a Close frame in response, the endpoint typically echos the status code it received.

This PR does just that, when a Close Frame is received, it echoes it to the other endpoint.