### PR TITLE
Example code clarity improvement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@ _cgo_export.*
 _testmain.go
 
 *.exe
+
+.idea/
+*.iml

--- a/examples/chat/conn.go
+++ b/examples/chat/conn.go
@@ -40,16 +40,16 @@ type connection struct {
 }
 
 // readPump pumps messages from the websocket connection to the hub.
-func (c *connection) readPump() {
+func (conn *connection) readPump() {
 	defer func() {
-		mainHub.unregister <- c
-		c.ws.Close()
+		mainHub.unregister <- conn
+		conn.ws.Close()
 	}()
-	c.ws.SetReadLimit(maxMessageSize)
-	c.ws.SetReadDeadline(time.Now().Add(pongWait))
-	c.ws.SetPongHandler(func(string) error { c.ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
+	conn.ws.SetReadLimit(maxMessageSize)
+	conn.ws.SetReadDeadline(time.Now().Add(pongWait))
+	conn.ws.SetPongHandler(func(string) error { conn.ws.SetReadDeadline(time.Now().Add(pongWait)); return nil })
 	for {
-		_, message, err := c.ws.ReadMessage()
+		_, message, err := conn.ws.ReadMessage()
 		if err != nil {
 			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
 				log.Printf("error: %v", err)
@@ -61,30 +61,30 @@ func (c *connection) readPump() {
 }
 
 // write writes a message with the given message type and payload.
-func (c *connection) write(mt int, payload []byte) error {
-	c.ws.SetWriteDeadline(time.Now().Add(writeWait))
-	return c.ws.WriteMessage(mt, payload)
+func (conn *connection) write(mt int, payload []byte) error {
+	conn.ws.SetWriteDeadline(time.Now().Add(writeWait))
+	return conn.ws.WriteMessage(mt, payload)
 }
 
 // writePump pumps messages from the hub to the websocket connection.
-func (c *connection) writePump() {
+func (conn *connection) writePump() {
 	ticker := time.NewTicker(pingPeriod)
 	defer func() {
 		ticker.Stop()
-		c.ws.Close()
+		conn.ws.Close()
 	}()
 	for {
 		select {
-		case message, ok := <-c.send:
+		case message, ok := <-conn.send:
 			if !ok {
-				c.write(websocket.CloseMessage, []byte{})
+				conn.write(websocket.CloseMessage, []byte{})
 				return
 			}
-			if err := c.write(websocket.TextMessage, message); err != nil {
+			if err := conn.write(websocket.TextMessage, message); err != nil {
 				return
 			}
 		case <-ticker.C:
-			if err := c.write(websocket.PingMessage, []byte{}); err != nil {
+			if err := conn.write(websocket.PingMessage, []byte{}); err != nil {
 				return
 			}
 		}
@@ -98,8 +98,8 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 		log.Println(err)
 		return
 	}
-	c := &connection{send: make(chan []byte, 256), ws: ws}
-	mainHub.register <- c
-	go c.writePump()
-	c.readPump()
+	conn := &connection{send: make(chan []byte, 256), ws: ws}
+	mainHub.register <- conn
+	go conn.writePump()
+	conn.readPump()
 }

--- a/examples/chat/conn.go
+++ b/examples/chat/conn.go
@@ -42,7 +42,7 @@ type connection struct {
 // readPump pumps messages from the websocket connection to the hub.
 func (c *connection) readPump() {
 	defer func() {
-		h.unregister <- c
+		mainHub.unregister <- c
 		c.ws.Close()
 	}()
 	c.ws.SetReadLimit(maxMessageSize)
@@ -56,7 +56,7 @@ func (c *connection) readPump() {
 			}
 			break
 		}
-		h.broadcast <- message
+		mainHub.broadcast <- message
 	}
 }
 
@@ -99,7 +99,7 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	c := &connection{send: make(chan []byte, 256), ws: ws}
-	h.register <- c
+	mainHub.register <- c
 	go c.writePump()
 	c.readPump()
 }

--- a/examples/chat/hub.go
+++ b/examples/chat/hub.go
@@ -20,30 +20,30 @@ type hub struct {
 	unregister chan *connection
 }
 
-var h = hub{
+var mainHub = hub{
 	broadcast:   make(chan []byte),
 	register:    make(chan *connection),
 	unregister:  make(chan *connection),
 	connections: make(map[*connection]bool),
 }
 
-func (h *hub) run() {
+func (hub *hub) run() {
 	for {
 		select {
-		case c := <-h.register:
-			h.connections[c] = true
-		case c := <-h.unregister:
-			if _, ok := h.connections[c]; ok {
-				delete(h.connections, c)
+		case c := <-hub.register:
+			hub.connections[c] = true
+		case c := <-hub.unregister:
+			if _, ok := hub.connections[c]; ok {
+				delete(hub.connections, c)
 				close(c.send)
 			}
-		case m := <-h.broadcast:
-			for c := range h.connections {
+		case m := <-hub.broadcast:
+			for c := range hub.connections {
 				select {
 				case c.send <- m:
 				default:
 					close(c.send)
-					delete(h.connections, c)
+					delete(hub.connections, c)
 				}
 			}
 		}

--- a/examples/chat/hub.go
+++ b/examples/chat/hub.go
@@ -30,20 +30,20 @@ var mainHub = hub{
 func (hub *hub) run() {
 	for {
 		select {
-		case c := <-hub.register:
-			hub.connections[c] = true
-		case c := <-hub.unregister:
-			if _, ok := hub.connections[c]; ok {
-				delete(hub.connections, c)
-				close(c.send)
+		case conn := <-hub.register:
+			hub.connections[conn] = true
+		case conn := <-hub.unregister:
+			if _, ok := hub.connections[conn]; ok {
+				delete(hub.connections, conn)
+				close(conn.send)
 			}
-		case m := <-hub.broadcast:
-			for c := range hub.connections {
+		case message := <-hub.broadcast:
+			for conn := range hub.connections {
 				select {
-				case c.send <- m:
+				case conn.send <- message:
 				default:
-					close(c.send)
-					delete(hub.connections, c)
+					close(conn.send)
+					delete(hub.connections, conn)
 				}
 			}
 		}

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -12,7 +12,7 @@ import (
 )
 
 var addr = flag.String("addr", ":8080", "http service address")
-var homeTempl = template.Must(template.ParseFiles("home.html"))
+var homeTemplate = template.Must(template.ParseFiles("home.html"))
 
 func serveHome(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
@@ -24,12 +24,12 @@ func serveHome(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	homeTempl.Execute(w, r.Host)
+	homeTemplate.Execute(w, r.Host)
 }
 
 func main() {
 	flag.Parse()
-	go h.run()
+	go mainHub.run()
 	http.HandleFunc("/", serveHome)
 	http.HandleFunc("/ws", serveWs)
 	err := http.ListenAndServe(*addr, nil)


### PR DESCRIPTION
At the moment it's a little hard to figure out what's going on when a bunch of variables are `h`, `c`, `m`, and so on. This is pretty normal shorthand Go users, but in example code it's quicker to understand if shorthand is avoided.

edit: Happy to refactor the names to something else if you prefer. `mainHub` especially I don't love.