### PR TITLE
add cookie jar to dialer

### DIFF
--- a/client.go
+++ b/client.go
@@ -78,6 +78,11 @@ type Dialer struct {
 	// guarantee that compression will be supported. Currently only "no context
 	// takeover" modes are supported.
 	EnableCompression bool
+
+	// Jar specifies the cookie jar.
+	// If Jar is nil, cookies are not sent in requests and ignored
+	// in responses.
+	Jar http.CookieJar
 }
 
 var errMalformedURL = errors.New("malformed ws or wss URL")
@@ -91,7 +96,6 @@ func parseURL(s string) (*url.URL, error) {
 	//
 	// ws-URI = "ws:" "//" host [ ":" port ] path [ "?" query ]
 	// wss-URI = "wss:" "//" host [ ":" port ] path [ "?" query ]
-
 	var u url.URL
 	switch {
 	case strings.HasPrefix(s, "ws://"):
@@ -199,6 +203,13 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 		ProtoMinor: 1,
 		Header:     make(http.Header),
 		Host:       u.Host,
+	}
+
+	// Set the cookies present in the cookie jar of the dialer
+	if d.Jar != nil {
+		for _, cookie := range d.Jar.Cookies(u) {
+			req.AddCookie(cookie)
+		}
 	}
 
 	// Set the request headers using the capitalization for names and values in
@@ -337,6 +348,13 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 	if err != nil {
 		return nil, nil, err
 	}
+
+	if d.Jar != nil {
+		if rc := resp.Cookies(); len(rc) > 0 {
+			d.Jar.SetCookies(u, rc)
+		}
+	}
+
 	if resp.StatusCode != 101 ||
 		!strings.EqualFold(resp.Header.Get("Upgrade"), "websocket") ||
 		!strings.EqualFold(resp.Header.Get("Connection"), "upgrade") ||

--- a/client_server_test.go
+++ b/client_server_test.go
@@ -11,6 +11,7 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"net/http/cookiejar"
 	"net/http/httptest"
 	"net/url"
 	"reflect"
@@ -225,6 +226,54 @@ func TestDial(t *testing.T) {
 		t.Fatalf("Dial: %v", err)
 	}
 	defer ws.Close()
+	sendRecv(t, ws)
+}
+
+func TestDialCookieJar(t *testing.T) {
+	s := newServer(t)
+	defer s.Close()
+
+	jar, _ := cookiejar.New(nil)
+	d := cstDialer
+	d.Jar = jar
+
+	u, _ := parseURL(s.URL)
+
+	switch u.Scheme {
+	case "ws":
+		u.Scheme = "http"
+	case "wss":
+		u.Scheme = "https"
+	}
+
+	cookies := []*http.Cookie{&http.Cookie{Name: "gorilla", Value: "ws", Path: "/"}}
+	d.Jar.SetCookies(u, cookies)
+
+	ws, _, err := d.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	defer ws.Close()
+
+	var gorilla string
+	var sessionID string
+	for _, c := range d.Jar.Cookies(u) {
+		if c.Name == "gorilla" {
+			gorilla = c.Value
+		}
+
+		if c.Name == "sessionID" {
+			sessionID = c.Value
+		}
+	}
+	if gorilla != "ws" {
+		t.Error("Cookie not present in jar.")
+	}
+
+	if sessionID != "1234" {
+		t.Error("Set-Cookie not received from the server.")
+	}
+
 	sendRecv(t, ws)
 }
 


### PR DESCRIPTION
This allows users to add a cookie jar the same way it can be done for the `http.Client` of the `net/http` package

Example:

```
import (
	"net"
	"net/http"
	"net/http/cookiejar"

	"github.com/gorilla/websocket"
)

func main () {
    var jar http.CookieJar
    jar, _ = cookiejar.New(nil)

    Url := "http://example.com"
    Dialer := websocket.Dialer{Jar: jar}
    header := http.Header{}
    ws, res, err := Dialer.Dial(Url, header)

    ...
}
```