### PR TITLE
Add the SetDeadline method on the connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -292,6 +292,8 @@ func newConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int) 
 	return c
 }
 
+// SetDeadline sets the read and write deadline on the underlying network connection
+// It is equivalent to calling both SetReadDeadline and SetWriteDeadline.
 func (c *Conn) SetDeadline(t time.Time) error {
 	c.writeDeadline = t
 	return c.conn.SetDeadline(t)

--- a/conn.go
+++ b/conn.go
@@ -292,6 +292,11 @@ func newConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int) 
 	return c
 }
 
+func (c *Conn) SetDeadline(t time.Time) error {
+	c.writeDeadline = t
+	return c.conn.SetDeadline(t)
+}
+
 // Subprotocol returns the negotiated protocol for the connection.
 func (c *Conn) Subprotocol() string {
 	return c.subprotocol


### PR DESCRIPTION
I was using recently the deadlines and noticed that the SetDeadline method of the connection is missing.