### PR TITLE
fix flate write pool size to work with best compression

### DIFF
--- a/compression.go
+++ b/compression.go
@@ -19,7 +19,7 @@ const (
 )
 
 var (
-	flateWriterPools [maxCompressionLevel - minCompressionLevel]sync.Pool
+	flateWriterPools [maxCompressionLevel - minCompressionLevel + 1]sync.Pool
 	flateReaderPool  = sync.Pool{New: func() interface{} {
 		return flate.NewReader(nil)
 	}}

--- a/compression_test.go
+++ b/compression_test.go
@@ -41,28 +41,6 @@ func textMessages(num int) [][]byte {
 	return messages
 }
 
-func TestCompressNoContextTakeover(t *testing.T) {
-	for level := minCompressionLevel; level <= maxCompressionLevel; level++ {
-		message := textMessages(1)[0]
-		c := fakeNetConn{Reader: nil, Writer: ioutil.Discard}
-		f := compressNoContextTakeover(c, level)
-		n, err := f.Write(message)
-		if err != nil {
-			t.Errorf("Error writing using compressNoContextTakeover on level %d: %v", level, err)
-			return
-		}
-		if n != len(message) {
-			t.Errorf("Error writing using compressNoContextTakeover on level %d: not enough bytes written", level)
-			return
-		}
-		err = f.Close()
-		if err != nil {
-			t.Errorf("Error closing writer on level %d: %v", level, err)
-			return
-		}
-	}
-}
-
 func BenchmarkWriteNoCompression(b *testing.B) {
 	w := ioutil.Discard
 	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)

--- a/compression_test.go
+++ b/compression_test.go
@@ -41,6 +41,28 @@ func textMessages(num int) [][]byte {
 	return messages
 }
 
+func TestCompressNoContextTakeover(t *testing.T) {
+	for level := minCompressionLevel; level <= maxCompressionLevel; level++ {
+		message := textMessages(1)[0]
+		c := fakeNetConn{Reader: nil, Writer: ioutil.Discard}
+		f := compressNoContextTakeover(c, level)
+		n, err := f.Write(message)
+		if err != nil {
+			t.Errorf("Error writing using compressNoContextTakeover on level %d: %v", level, err)
+			return
+		}
+		if n != len(message) {
+			t.Errorf("Error writing using compressNoContextTakeover on level %d: not enough bytes written", level)
+			return
+		}
+		err = f.Close()
+		if err != nil {
+			t.Errorf("Error closing writer on level %d: %v", level, err)
+			return
+		}
+	}
+}
+
 func BenchmarkWriteNoCompression(b *testing.B) {
 	w := ioutil.Discard
 	c := newConn(fakeNetConn{Reader: nil, Writer: w}, false, 1024, 1024)


### PR DESCRIPTION
Currently SetCompressionLevel panics: `index out of range`.