### PR TITLE
Add code snippet for EnableCompression in doc.go

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -156,14 +156,20 @@
 // Per message compression extensions (RFC 7692) are experimentally supported
 // by this package in a limited capacity. Setting the EnableCompression option
 // to true in Dialer or Upgrader will attempt to negotiate per message deflate
-// support. If compression was successfully negotiated with the connection's
-// peer, any message received in compressed form will be automatically
-// decompressed. All Read methods will return uncompressed bytes.
+// support.
+//
+//  var upgrader = websocket.Upgrader{
+//      EnableCompression: true,
+//  }
+//
+// If compression was successfully negotiated with the connection's peer, any
+// message received in compressed form will be automatically decompressed.
+// All Read methods will return uncompressed bytes.
 //
 // Per message compression of messages written to a connection can be enabled
 // or disabled by calling the corresponding Conn method:
 //
-//  conn.EnableWriteCompression(true)
+//  conn.EnableWriteCompression(false)
 //
 // Currently this package does not support compression with "context takeover".
 // This means that messages must be compressed and decompressed in isolation,


### PR DESCRIPTION
I thought code snippet catches attention well in general, and it's nice to have it for `EnableCompression`.

Maybe it's just me, but I tried to add `EnableWriteCompression(true)` to my code first before reading the whole paragraph. Then I realized `EnableCompression` is the one necessary while `enableWriteCompression` is actually true by default if `EnableCompression` is on.