### PR TITLE
Change text/template to html/template in the examples

### DIFF
--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -6,9 +6,9 @@ package main
 
 import (
 	"flag"
+	"html/template"
 	"log"
 	"net/http"
-	"html/template"
 )
 
 var addr = flag.String("addr", ":8080", "http service address")

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -8,7 +8,7 @@ import (
 	"flag"
 	"log"
 	"net/http"
-	"text/template"
+	"html/template"
 )
 
 var addr = flag.String("addr", ":8080", "http service address")

--- a/examples/command/main.go
+++ b/examples/command/main.go
@@ -7,12 +7,12 @@ package main
 import (
 	"bufio"
 	"flag"
+	"html/template"
 	"io"
 	"log"
 	"net/http"
 	"os"
 	"os/exec"
-	"html/template"
 	"time"
 
 	"github.com/gorilla/websocket"

--- a/examples/command/main.go
+++ b/examples/command/main.go
@@ -12,7 +12,7 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/gorilla/websocket"

--- a/examples/filewatch/main.go
+++ b/examples/filewatch/main.go
@@ -11,7 +11,7 @@ import (
 	"net/http"
 	"os"
 	"strconv"
-	"text/template"
+	"html/template"
 	"time"
 
 	"github.com/gorilla/websocket"

--- a/examples/filewatch/main.go
+++ b/examples/filewatch/main.go
@@ -6,12 +6,12 @@ package main
 
 import (
 	"flag"
-	"io/ioutil"
+	"html/template"
+	"io/ioutil"	
 	"log"
 	"net/http"
 	"os"
 	"strconv"
-	"html/template"
 	"time"
 
 	"github.com/gorilla/websocket"

--- a/examples/filewatch/main.go
+++ b/examples/filewatch/main.go
@@ -7,7 +7,7 @@ package main
 import (
 	"flag"
 	"html/template"
-	"io/ioutil"	
+	"io/ioutil"
 	"log"
 	"net/http"
 	"os"


### PR DESCRIPTION
From the documentation on [html/template](https://golang.org/pkg/html/template/):

> Package template (html/template) implements data-driven templates for generating HTML output safe against code injection. It provides the same interface as package text/template and should be used instead of text/template whenever the output is HTML.

Since some of the files in the examples were parsing HTML with `text/template`, I've updated them to the recommended `html/template`. It is important to make this update because the examples in this repo are likely used as reference material by beginners thus should exhibit best practices.