### PR TITLE
Enable client compression based on response header

### DIFF
--- a/client.go
+++ b/client.go
@@ -369,7 +369,7 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 		return nil, resp, ErrBadHandshake
 	}
 
-	for _, ext := range parseExtensions(req.Header) {
+	for _, ext := range parseExtensions(resp.Header) {
 		if ext[""] != "permessage-deflate" {
 			continue
 		}


### PR DESCRIPTION
At moment client always tries to use compression when `EnableCompression` is on in `Dialer` - even if server does not want to negotiate it.