### PR TITLE
Recover from read timeouted connection

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -958,7 +958,13 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 		panic("repeated read on failed websocket connection")
 	}
 
-	return noFrame, nil, c.readErr
+	err = c.readErr
+	if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
+		c.readErr = nil
+		c.readErrCount--
+	}
+
+	return noFrame, nil, err
 }
 
 type messageReader struct{ c *Conn }


### PR DESCRIPTION
```
retry := 10
again:
for {
    wscon.SetReadDeadline(time.Now().Add(pongWaitTime))
    tp, message, err := wscon.ReadMessage()
    fmt.Printf("request: %s, %d\n", string(message), tp)
    if len(message) == 0 && err != nil {
        if netErr, ok := err.(net.Error); ok && netErr.Timeout() {
	    // time out
            // send ping and goto again
            retry--
            if retry > 0 {
                kindOfPing, _ := json.Marshal(map[string]string{})
		if err := this.wscon.WriteMessage(websocket.TextMessage, s); err != nil {
		    break
		}
                <-time.After(time.Second * 2)
                goto again
            }
        }
	break
    }
    ProcessMessage(message)
}
```

in this case if ReadMessage fails only once because of Timeout error, all other following reads will fail. But this is not fatal error, websocket is open and receiver is receiving `kindOfPing` messages and responds to it. Response is also coming to server listening for this websocket