### PR TITLE
removing the hardcoded 127.0.0.1

### DIFF
--- a/examples/command/main.go
+++ b/examples/command/main.go
@@ -18,7 +18,7 @@ import (
 )
 
 var (
-	addr    = flag.String("addr", "127.0.0.1:8080", "http service address")
+	addr    = flag.String("addr", ":8080", "http service address")
 	cmdPath string
 )
 


### PR DESCRIPTION
makes it easy to connect when running the code in a remote VM, for example.