### PR TITLE
Add missing html tag in example/echo

### DIFF
--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -55,6 +55,7 @@ func main() {
 
 var homeTemplate = template.Must(template.New("").Parse(`
 <!DOCTYPE html>
+<html>
 <head>
 <meta charset="utf-8">
 <script>  


### PR DESCRIPTION
The opening `<html>` tag is missing.
