### PR TITLE
Typo fix

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -76,7 +76,7 @@ const (
 	// is UTF-8 encoded text.
 	PingMessage = 9
 
-	// PongMessage denotes a ping control message. The optional message payload
+	// PongMessage denotes a pong control message. The optional message payload
 	// is UTF-8 encoded text.
 	PongMessage = 10
 )


### PR DESCRIPTION
_These two messages are also sometimes called "ping" and "pong"_ — [Wiki](https://en.wikipedia.org/wiki/Ping-pong_scheme#Internet)