### PR TITLE
refine Conn.SetReadDeadline

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -13,10 +13,10 @@ import (
 	"math/rand"
 	"net"
 	"strconv"
+	"strings"
 	"sync"
 	"time"
 	"unicode/utf8"
-	"strings"
 )
 
 const (

--- a/conn.go
+++ b/conn.go
@@ -16,6 +16,7 @@ import (
 	"sync"
 	"time"
 	"unicode/utf8"
+	"strings"
 )
 
 const (
@@ -1029,6 +1030,9 @@ func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
 // all future reads will return an error. A zero value for t means reads will
 // not time out.
 func (c *Conn) SetReadDeadline(t time.Time) error {
+	if c.readErr != nil && strings.Contains(c.readErr.Error(), "i/o timeout") {
+		c.readErr = nil
+	}
 	return c.conn.SetReadDeadline(t)
 }
 


### PR DESCRIPTION
Under my circumstance

I want to use the websocket connection **Half-duplex**

e.g.
```go
    conn, _ := upgrader.Upgrade(w, r, nil)
    for {
        conn.SetReadDeadline(time.Now().Add(time.Second * 3))
        err := c.Conn.ReadJSON(&p)
        // do something...
        if err != nil && strings.Contains(err.Error(), "i/o timeout") {
            // read timeout do something
        } else if err == nil {
            // parse the data from client
        } else {
            // process the other err
        }
    }
```

**but** 
 **readErr** of Conn is always not nil after the first read timeout so the code above will panic due to 
the code in Conn.NextReader
```go
func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
        ...
        // always not nil after first timeout
	for c.readErr == nil {
		...
	}

	// panic...
	c.readErrCount++
	if c.readErrCount >= 1000 {
		panic("repeated read on failed websocket connection")
	}

	return noFrame, nil, c.readErr
}
```