### PR TITLE
Replace parseURL() with net/url.Parse() (#290)

### DIFF
--- a/client.go
+++ b/client.go
@@ -88,50 +88,6 @@ type Dialer struct {
 
 var errMalformedURL = errors.New("malformed ws or wss URL")
 
-// parseURL parses the URL.
-//
-// This function is a replacement for the standard library url.Parse function.
-// In Go 1.4 and earlier, url.Parse loses information from the path.
-func parseURL(s string) (*url.URL, error) {
-	// From the RFC:
-	//
-	// ws-URI = "ws:" "//" host [ ":" port ] path [ "?" query ]
-	// wss-URI = "wss:" "//" host [ ":" port ] path [ "?" query ]
-	var u url.URL
-	switch {
-	case strings.HasPrefix(s, "ws://"):
-		u.Scheme = "ws"
-		s = s[len("ws://"):]
-	case strings.HasPrefix(s, "wss://"):
-		u.Scheme = "wss"
-		s = s[len("wss://"):]
-	default:
-		return nil, errMalformedURL
-	}
-
-	if i := strings.Index(s, "?"); i >= 0 {
-		u.RawQuery = s[i+1:]
-		s = s[:i]
-	}
-
-	if i := strings.Index(s, "/"); i >= 0 {
-		u.Opaque = s[i:]
-		s = s[:i]
-	} else {
-		u.Opaque = "/"
-	}
-
-	u.Host = s
-
-	if strings.Contains(u.Host, "@") {
-		// Don't bother parsing user information because user information is
-		// not allowed in websocket URIs.
-		return nil, errMalformedURL
-	}
-
-	return &u, nil
-}
-
 func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
 	hostPort = u.Host
 	hostNoPort = u.Host
@@ -177,7 +133,7 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 		return nil, nil, err
 	}
 
-	u, err := parseURL(urlStr)
+	u, err := url.Parse(urlStr)
 	if err != nil {
 		return nil, nil, err
 	}

--- a/client_server_test.go
+++ b/client_server_test.go
@@ -237,7 +237,7 @@ func TestDialCookieJar(t *testing.T) {
 	d := cstDialer
 	d.Jar = jar
 
-	u, _ := parseURL(s.URL)
+	u, _ := url.Parse(s.URL)
 
 	switch u.Scheme {
 	case "ws":

--- a/client_test.go
+++ b/client_test.go
@@ -6,48 +6,8 @@ package websocket
 
 import (
 	"net/url"
-	"reflect"
 	"testing"
 )
-
-var parseURLTests = []struct {
-	s   string
-	u   *url.URL
-	rui string
-}{
-	{"ws://example.com/", &url.URL{Scheme: "ws", Host: "example.com", Opaque: "/"}, "/"},
-	{"ws://example.com", &url.URL{Scheme: "ws", Host: "example.com", Opaque: "/"}, "/"},
-	{"ws://example.com:7777/", &url.URL{Scheme: "ws", Host: "example.com:7777", Opaque: "/"}, "/"},
-	{"wss://example.com/", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/"}, "/"},
-	{"wss://example.com/a/b", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/a/b"}, "/a/b"},
-	{"ss://example.com/a/b", nil, ""},
-	{"ws://webmaster@example.com/", nil, ""},
-	{"wss://example.com/a/b?x=y", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/a/b", RawQuery: "x=y"}, "/a/b?x=y"},
-	{"wss://example.com?x=y", &url.URL{Scheme: "wss", Host: "example.com", Opaque: "/", RawQuery: "x=y"}, "/?x=y"},
-}
-
-func TestParseURL(t *testing.T) {
-	for _, tt := range parseURLTests {
-		u, err := parseURL(tt.s)
-		if tt.u != nil && err != nil {
-			t.Errorf("parseURL(%q) returned error %v", tt.s, err)
-			continue
-		}
-		if tt.u == nil {
-			if err == nil {
-				t.Errorf("parseURL(%q) did not return error", tt.s)
-			}
-			continue
-		}
-		if !reflect.DeepEqual(u, tt.u) {
-			t.Errorf("parseURL(%q) = %v, want %v", tt.s, u, tt.u)
-			continue
-		}
-		if u.RequestURI() != tt.rui {
-			t.Errorf("parseURL(%q).RequestURI() = %v, want %v", tt.s, u.RequestURI(), tt.rui)
-		}
-	}
-}
 
 var hostPortNoPortTests = []struct {
 	u                    *url.URL


### PR DESCRIPTION
Fixes #290. Tested OK with our Proxy impl.

I've also removed TestParseURL().