### PR TITLE
Simplify and fix spelling errors in test files

### DIFF
--- a/client_server_test.go
+++ b/client_server_test.go
@@ -160,8 +160,8 @@ func TestProxyDial(t *testing.T) {
 			}
 
 			if !connect {
-				t.Log("connect not recieved")
-				http.Error(w, "connect not recieved", 405)
+				t.Log("connect not received")
+				http.Error(w, "connect not received", 405)
 				return
 			}
 			origHandler.ServeHTTP(w, r)
@@ -200,8 +200,8 @@ func TestProxyAuthorizationDial(t *testing.T) {
 			}
 
 			if !connect {
-				t.Log("connect with proxy authorization not recieved")
-				http.Error(w, "connect with proxy authorization not recieved", 405)
+				t.Log("connect with proxy authorization not received")
+				http.Error(w, "connect with proxy authorization not received", 405)
 				return
 			}
 			origHandler.ServeHTTP(w, r)
@@ -246,7 +246,7 @@ func TestDialCookieJar(t *testing.T) {
 		u.Scheme = "https"
 	}
 
-	cookies := []*http.Cookie{&http.Cookie{Name: "gorilla", Value: "ws", Path: "/"}}
+	cookies := []*http.Cookie{{Name: "gorilla", Value: "ws", Path: "/"}}
 	d.Jar.SetCookies(u, cookies)
 
 	ws, _, err := d.Dial(s.URL, nil)

--- a/conn_test.go
+++ b/conn_test.go
@@ -366,7 +366,7 @@ func TestBufioReadBytes(t *testing.T) {
 		t.Fatalf("ReadBytes() returned %v", err)
 	}
 	if len(p) != len(m) {
-		t.Fatalf("read returnd %d bytes, want %d bytes", len(p), len(m))
+		t.Fatalf("read returned %d bytes, want %d bytes", len(p), len(m))
 	}
 }
 

--- a/util_test.go
+++ b/util_test.go
@@ -38,29 +38,29 @@ var parseExtensionTests = []struct {
 	value      string
 	extensions []map[string]string
 }{
-	{`foo`, []map[string]string{map[string]string{"": "foo"}}},
+	{`foo`, []map[string]string{{"": "foo"}}},
 	{`foo, bar; baz=2`, []map[string]string{
-		map[string]string{"": "foo"},
-		map[string]string{"": "bar", "baz": "2"}}},
+		{"": "foo"},
+		{"": "bar", "baz": "2"}}},
 	{`foo; bar="b,a;z"`, []map[string]string{
-		map[string]string{"": "foo", "bar": "b,a;z"}}},
+		{"": "foo", "bar": "b,a;z"}}},
 	{`foo , bar; baz = 2`, []map[string]string{
-		map[string]string{"": "foo"},
-		map[string]string{"": "bar", "baz": "2"}}},
+		{"": "foo"},
+		{"": "bar", "baz": "2"}}},
 	{`foo, bar; baz=2 junk`, []map[string]string{
-		map[string]string{"": "foo"}}},
+		{"": "foo"}}},
 	{`foo junk, bar; baz=2 junk`, nil},
 	{`mux; max-channels=4; flow-control, deflate-stream`, []map[string]string{
-		map[string]string{"": "mux", "max-channels": "4", "flow-control": ""},
-		map[string]string{"": "deflate-stream"}}},
+		{"": "mux", "max-channels": "4", "flow-control": ""},
+		{"": "deflate-stream"}}},
 	{`permessage-foo; x="10"`, []map[string]string{
-		map[string]string{"": "permessage-foo", "x": "10"}}},
+		{"": "permessage-foo", "x": "10"}}},
 	{`permessage-foo; use_y, permessage-foo`, []map[string]string{
-		map[string]string{"": "permessage-foo", "use_y": ""},
-		map[string]string{"": "permessage-foo"}}},
+		{"": "permessage-foo", "use_y": ""},
+		{"": "permessage-foo"}}},
 	{`permessage-deflate; client_max_window_bits; server_max_window_bits=10 , permessage-deflate; client_max_window_bits`, []map[string]string{
-		map[string]string{"": "permessage-deflate", "client_max_window_bits": "", "server_max_window_bits": "10"},
-		map[string]string{"": "permessage-deflate", "client_max_window_bits": ""}}},
+		{"": "permessage-deflate", "client_max_window_bits": "", "server_max_window_bits": "10"},
+		{"": "permessage-deflate", "client_max_window_bits": ""}}},
 }
 
 func TestParseExtensions(t *testing.T) {


### PR DESCRIPTION
Simplify using gofmt -s.