### PR TITLE
More consistent error handling in doc

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -30,10 +30,12 @@
 //  for {
 //      messageType, p, err := conn.ReadMessage()
 //      if err != nil {
+//          log.Println(err)
 //          return
 //      }
 //      if err := conn.WriteMessage(messageType, p); err != nil {
-//          return err
+//          log.Println(err)
+//          return
 //      }
 //  }
 //


### PR DESCRIPTION
I noticed the example is actually wrong as the same block both calls `return` with no parameter and `return err`. I think it would be better to allow the code to be used directly. I added calls to log.Println as it was used on the other example as it might be more useful for newcomers to see error messages.