### PR TITLE
origin host check should be case insensitive

### DIFF
--- a/server.go
+++ b/server.go
@@ -76,7 +76,7 @@ func checkSameOrigin(r *http.Request) bool {
 	if err != nil {
 		return false
 	}
-	return strings.ToLower(u.Host) == strings.ToLower(r.Host)
+	return equalASCIIFold(u.Host, r.Host)
 }
 
 func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {

--- a/server.go
+++ b/server.go
@@ -76,7 +76,7 @@ func checkSameOrigin(r *http.Request) bool {
 	if err != nil {
 		return false
 	}
-	return strings.EqualFold(u.Host, r.Host)
+	return strings.ToLower(u.Host) == strings.ToLower(r.Host)
 }
 
 func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {

--- a/server.go
+++ b/server.go
@@ -76,7 +76,7 @@ func checkSameOrigin(r *http.Request) bool {
 	if err != nil {
 		return false
 	}
-	return u.Host == r.Host
+	return strings.EqualFold(u.Host, r.Host)
 }
 
 func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header) string {

--- a/server_test.go
+++ b/server_test.go
@@ -49,3 +49,21 @@ func TestIsWebSocketUpgrade(t *testing.T) {
 		}
 	}
 }
+
+var checkSameOriginTests = []struct {
+	ok bool
+	r  *http.Request
+}{
+	{false, &http.Request{Host: "example.org", Header: map[string][]string{"Origin": []string{"https://other.org"}}}},
+	{true, &http.Request{Host: "example.org", Header: map[string][]string{"Origin": []string{"https://example.org"}}}},
+	{true, &http.Request{Host: "Example.org", Header: map[string][]string{"Origin": []string{"https://example.org"}}}},
+}
+
+func TestCheckSameOrigin(t *testing.T) {
+	for _, tt := range checkSameOriginTests {
+		ok := checkSameOrigin(tt.r)
+		if tt.ok != ok {
+			t.Errorf("checkSameOrigin(%+v) returned %v, want %v", tt.r, ok, tt.ok)
+		}
+	}
+}


### PR DESCRIPTION
According to [RFC 4343](https://tools.ietf.org/html/rfc4343) DNS hostnames should be case insensitive. This modifies the `checkSameOrigin()` helper to compare hosts without case sensitivity.