### PR TITLE
examples/chat/client.go: avoid allocating []byte{} for PingMessage

### DIFF
--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -113,7 +113,7 @@ func (c *Client) writePump() {
 			}
 		case <-ticker.C:
 			c.conn.SetWriteDeadline(time.Now().Add(writeWait))
-			if err := c.conn.WriteMessage(websocket.PingMessage, []byte{}); err != nil {
+			if err := c.conn.WriteMessage(websocket.PingMessage, nil); err != nil {
 				return
 			}
 		}


### PR DESCRIPTION
It's useless and only gives more work to the GC.