### PR TITLE
Improve emample: chat

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -44,7 +44,7 @@ Clients send requests to the hub using the `register`, `unregister` and
 `broadcast` channels.
 
 The hub registers clients by adding the client pointer as a key in the
-`clients` map. The map value is always true.
+`clients` map. The map value is empty struct.
 
 The unregister code is a little more complicated. In addition to deleting the
 client pointer from the `clients` map, the hub closes the clients's `send`

--- a/examples/chat/hub.go
+++ b/examples/chat/hub.go
@@ -8,7 +8,7 @@ package main
 // clients.
 type Hub struct {
 	// Registered clients.
-	clients map[*Client]bool
+	clients map[*Client]struct{}
 
 	// Inbound messages from the clients.
 	broadcast chan []byte
@@ -25,7 +25,7 @@ func newHub() *Hub {
 		broadcast:  make(chan []byte),
 		register:   make(chan *Client),
 		unregister: make(chan *Client),
-		clients:    make(map[*Client]bool),
+		clients:    make(map[*Client]struct{}),
 	}
 }
 
@@ -33,7 +33,7 @@ func (h *Hub) run() {
 	for {
 		select {
 		case client := <-h.register:
-			h.clients[client] = true
+			h.clients[client] = struct{}{}
 		case client := <-h.unregister:
 			if _, ok := h.clients[client]; ok {
 				delete(h.clients, client)


### PR DESCRIPTION
- Use empty struct instead of bool in Hub struct:
`clients map[*Client]bool` -> `clients map[*Client]struct{}`
- Update README.md