### PR TITLE
Expose internal buffer reader for read raw data

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1119,6 +1119,12 @@ func (c *Conn) UnderlyingConn() net.Conn {
 	return c.conn
 }
 
+// BufferReader returns the internal buffer reader. This can be used to read
+// the raw data after upgrade success
+func (c *Conn) BufferReader() *bufio.Reader {
+	return c.br
+}
+
 // EnableWriteCompression enables and disables write compression of
 // subsequent text and binary messages. This function is a noop if
 // compression was not negotiated with the peer.


### PR DESCRIPTION
We use gorilla/websocket in [traefik](https://github.com/containous/traefik) in order to reverse-proxying websocket traffic.

What we want to do is to use gorilla/websocket for the Upgrade processes (client <=> reverse-proxy and reverse-proxy <=> server proxyfied) and then `io.Copy` the underlying connection in order to transfer the raw traffic. (like [here](https://github.com/vulcand/oxy/blob/master/forward/fwd.go#L346)  )

The issue we encounter with this, is that some servers embed websockets messages in the Switching Protocol body.
If it happens, those messages are not in the Underlying connection and are in the buffer reader in websocket.Conn ( `br` attribute).

That's why, we need to be able to access this buffer reader.

WDYT ?
  