### PR TITLE
Don't log 1006 error in chat example

### DIFF
--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -64,7 +64,7 @@ func (c *Client) readPump() {
 	for {
 		_, message, err := c.conn.ReadMessage()
 		if err != nil {
-			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway) {
+			if websocket.IsUnexpectedCloseError(err, websocket.CloseGoingAway, websocket.CloseAbnormalClosure) {
 				log.Printf("error: %v", err)
 			}
 			break


### PR DESCRIPTION
This error is expected (Safari closes connections without sending a close
frame).

Fixes #323