### PR TITLE
Modify http status code to variable

### DIFF
--- a/examples/autobahn/server.go
+++ b/examples/autobahn/server.go
@@ -157,11 +157,11 @@ func echoReadAllWritePreparedMessage(w http.ResponseWriter, r *http.Request) {
 
 func serveHome(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
-		http.Error(w, "Not found.", 404)
+		http.Error(w, "Not found.", http.StatusNotFound)
 		return
 	}
 	if r.Method != "GET" {
-		http.Error(w, "Method not allowed", 405)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/examples/chat/main.go
+++ b/examples/chat/main.go
@@ -15,11 +15,11 @@ var addr = flag.String("addr", ":8080", "http service address")
 func serveHome(w http.ResponseWriter, r *http.Request) {
 	log.Println(r.URL)
 	if r.URL.Path != "/" {
-		http.Error(w, "Not found", 404)
+		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}
 	if r.Method != "GET" {
-		http.Error(w, "Method not allowed", 405)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	http.ServeFile(w, r, "home.html")

--- a/examples/command/main.go
+++ b/examples/command/main.go
@@ -167,11 +167,11 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 
 func serveHome(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
-		http.Error(w, "Not found", 404)
+		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}
 	if r.Method != "GET" {
-		http.Error(w, "Method not allowed", 405)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	http.ServeFile(w, r, "home.html")

--- a/examples/filewatch/main.go
+++ b/examples/filewatch/main.go
@@ -130,11 +130,11 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 
 func serveHome(w http.ResponseWriter, r *http.Request) {
 	if r.URL.Path != "/" {
-		http.Error(w, "Not found", 404)
+		http.Error(w, "Not found", http.StatusNotFound)
 		return
 	}
 	if r.Method != "GET" {
-		http.Error(w, "Method not allowed", 405)
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
 		return
 	}
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")

--- a/server.go
+++ b/server.go
@@ -243,7 +243,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 // of the same origin policy check is:
 //
 //	if req.Header.Get("Origin") != "http://"+req.Host {
-//		http.Error(w, "Origin not allowed", 403)
+//		http.Error(w, "Origin not allowed", http.StatusForbidden)
 //		return
 //	}
 //


### PR DESCRIPTION
Go provides http status codes as const variables.

[Godoc](https://godoc.org/net/http#pkg-constants)