### PR TITLE
Add a default handshake timeout of 5 seconds

### DIFF
--- a/client.go
+++ b/client.go
@@ -41,7 +41,7 @@ func NewClient(netConn net.Conn, u *url.URL, requestHeader http.Header, readBufS
 		NetDial: func(net, addr string) (net.Conn, error) {
 			return netConn, nil
 		},
-		HandshakeTimeout: 5 * time.Second,
+		HandshakeTimeout: 45 * time.Second,
 	}
 	return d.Dial(u.String(), requestHeader)
 }
@@ -108,7 +108,7 @@ func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
 // DefaultDialer is a dialer with all fields set to the default values.
 var DefaultDialer = &Dialer{
 	Proxy:            http.ProxyFromEnvironment,
-	HandshakeTimeout: 5 * time.Second,
+	HandshakeTimeout: 45 * time.Second,
 }
 
 // Dial creates a new client connection. Use requestHeader to specify the
@@ -125,7 +125,7 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 	if d == nil {
 		d = &Dialer{
 			Proxy:            http.ProxyFromEnvironment,
-			HandshakeTimeout: 5 * time.Second,
+			HandshakeTimeout: 45 * time.Second,
 		}
 	}
 

--- a/client.go
+++ b/client.go
@@ -41,6 +41,7 @@ func NewClient(netConn net.Conn, u *url.URL, requestHeader http.Header, readBufS
 		NetDial: func(net, addr string) (net.Conn, error) {
 			return netConn, nil
 		},
+		HandshakeTimeout: 5 * time.Second,
 	}
 	return d.Dial(u.String(), requestHeader)
 }
@@ -106,7 +107,8 @@ func hostPortNoPort(u *url.URL) (hostPort, hostNoPort string) {
 
 // DefaultDialer is a dialer with all fields set to the default values.
 var DefaultDialer = &Dialer{
-	Proxy: http.ProxyFromEnvironment,
+	Proxy:            http.ProxyFromEnvironment,
+	HandshakeTimeout: 5 * time.Second,
 }
 
 // Dial creates a new client connection. Use requestHeader to specify the
@@ -122,7 +124,8 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 
 	if d == nil {
 		d = &Dialer{
-			Proxy: http.ProxyFromEnvironment,
+			Proxy:            http.ProxyFromEnvironment,
+			HandshakeTimeout: 5 * time.Second,
 		}
 	}
 


### PR DESCRIPTION
I'm adding this because while working with `nlopes/slack`, which in turn uses gorilla to deal with WebSockets, in a weird MTU related network failure, the behavior was that the client locks forever because there is no handshake timeout by default.

This way Gorilla will simply err out when the 5 seconds handshake timeout is passed (which, IMO, 5 seconds is a lot of time for a handshake)