### PR TITLE
Update LICENSE file to reflect Google employee contributions.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -4,5 +4,6 @@
 # Please keep the list sorted.
 
 Gary Burd <gary@beagledreams.com>
+Google LLC (https://opensource.google.com/)
 Joachim Bauch <mail@joachim-bauch.de>
 


### PR DESCRIPTION
As per https://opensource.google.com/docs/patching/#common-rules -

> If project authors are listed in a LICENSE, COPYING, AUTHORS or similar file, please add Google LLC. if it’s not already there. If Google Inc. is already listed then there is no need to change it to Google LLC. This step only applies if the project authors are listed somewhere.

Updating this to reflect a few boxes I need to tick.