### PR TITLE
Simplify code

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,7 @@ matrix:
     - go: 1.8.x
     - go: 1.9.x
     - go: 1.10.x
+    - go: 1.11.x
     - go: tip
   allow_failures:
     - go: tip

--- a/client.go
+++ b/client.go
@@ -122,7 +122,7 @@ var DefaultDialer = &Dialer{
 }
 
 // nilDialer is dialer to use when receiver is nil.
-var nilDialer Dialer = *DefaultDialer
+var nilDialer = *DefaultDialer
 
 // Dial creates a new client connection. Use requestHeader to specify the
 // origin (Origin), subprotocols (Sec-WebSocket-Protocol) and cookies (Cookie).

--- a/conn_broadcast_test.go
+++ b/conn_broadcast_test.go
@@ -2,8 +2,6 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-// +build go1.7
-
 package websocket
 
 import (

--- a/mask_test.go
+++ b/mask_test.go
@@ -2,8 +2,7 @@
 // this source code is governed by a BSD-style license that can be found in the
 // LICENSE file.
 
-// Require 1.7 for sub-bencmarks
-// +build go1.7,!appengine
+// !appengine
 
 package websocket
 

--- a/prepared.go
+++ b/prepared.go
@@ -19,7 +19,6 @@ import (
 type PreparedMessage struct {
 	messageType int
 	data        []byte
-	err         error
 	mu          sync.Mutex
 	frames      map[prepareKey]*preparedFrame
 }

--- a/server.go
+++ b/server.go
@@ -8,7 +8,6 @@ import (
 	"bufio"
 	"errors"
 	"io"
-	"net"
 	"net/http"
 	"net/url"
 	"strings"
@@ -171,17 +170,12 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 		}
 	}
 
-	var (
-		netConn net.Conn
-		err     error
-	)
-
 	h, ok := w.(http.Hijacker)
 	if !ok {
 		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
 	}
 	var brw *bufio.ReadWriter
-	netConn, brw, err = h.Hijack()
+	netConn, brw, err := h.Hijack()
 	if err != nil {
 		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
 	}
@@ -331,7 +325,7 @@ func IsWebSocketUpgrade(r *http.Request) bool {
 		tokenListContainsValue(r.Header, "Upgrade", "websocket")
 }
 
-// bufioReader size returns the size of a bufio.Reader.
+// bufioReaderSize size returns the size of a bufio.Reader.
 func bufioReaderSize(originalReader io.Reader, br *bufio.Reader) int {
 	// This code assumes that peek on a reset reader returns
 	// bufio.Reader.buf[:0].

--- a/server_test.go
+++ b/server_test.go
@@ -58,9 +58,9 @@ var checkSameOriginTests = []struct {
 	ok bool
 	r  *http.Request
 }{
-	{false, &http.Request{Host: "example.org", Header: map[string][]string{"Origin": []string{"https://other.org"}}}},
-	{true, &http.Request{Host: "example.org", Header: map[string][]string{"Origin": []string{"https://example.org"}}}},
-	{true, &http.Request{Host: "Example.org", Header: map[string][]string{"Origin": []string{"https://example.org"}}}},
+	{false, &http.Request{Host: "example.org", Header: map[string][]string{"Origin": {"https://other.org"}}}},
+	{true, &http.Request{Host: "example.org", Header: map[string][]string{"Origin": {"https://example.org"}}}},
+	{true, &http.Request{Host: "Example.org", Header: map[string][]string{"Origin": {"https://example.org"}}}},
 }
 
 func TestCheckSameOrigin(t *testing.T) {

--- a/util.go
+++ b/util.go
@@ -178,7 +178,7 @@ headers:
 	return false
 }
 
-// parseExtensiosn parses WebSocket extensions from a header.
+// parseExtensions parses WebSocket extensions from a header.
 func parseExtensions(header http.Header) []map[string]string {
 	// From RFC 6455:
 	//


### PR DESCRIPTION
- Use short variable declarations where possible.
- Remove unnecessary build tags after move to Go 1.7 min version.
- Simplify composite literals.
- Remove unused fields (err in PerparedMessage)