### PR TITLE
delete buffer on connection close

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -328,6 +328,8 @@ func (c *Conn) Subprotocol() string {
 // Close closes the underlying network connection without sending or waiting
 // for a close message.
 func (c *Conn) Close() error {
+	c.br = nil
+	c.writeBuf = nil
 	return c.conn.Close()
 }
 


### PR DESCRIPTION
Explicitly nil connection buffer on connection close. #141 #236 #273

What are your thoughts about explicitly deleting these buffers?

We are facing issues where process memory is ever increasing and it leads to crashing of process. To test, try allocating 10MB to ReadBufferSize & WriteBufferSize and have few connections loop connect & disconnect repeatedly.