### PR TITLE
decoding issue when they are large integer values during decoding process

### DIFF
--- a/json.go
+++ b/json.go
@@ -51,7 +51,9 @@ func (c *Conn) ReadJSON(v interface{}) error {
 	if err != nil {
 		return err
 	}
-	err = json.NewDecoder(r).Decode(v)
+	dec := json.NewDecoder(r)
+	dec.UseNumber()
+	err = dec.Decode(v)
 	if err == io.EOF {
 		// One value is expected in the message.
 		err = io.ErrUnexpectedEOF


### PR DESCRIPTION
decoding issue when they are large integer values during decoding process; previously it used to show up as xe+y for large integers during unmarshalling process