### PR TITLE
refresh connection status by SetReadDeadline

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1035,10 +1035,11 @@ func (c *Conn) ReadMessage() (messageType int, p []byte, err error) {
 }
 
 // SetReadDeadline sets the read deadline on the underlying network connection.
-// After a read has timed out, the websocket connection state is corrupt and
-// all future reads will return an error. A zero value for t means reads will
-// not time out.
+// After a read has timed out, the websocket connection state can be refreshed
+// by calling SetReadDeadline. A zero value for t means reads will not time out.
 func (c *Conn) SetReadDeadline(t time.Time) error {
+	c.readErr = nil
+	c.readErrCount = 0
 	return c.conn.SetReadDeadline(t)
 }
 


### PR DESCRIPTION
Purpose:
- Easier to reuse existing WS Connection, after read timeout occurred.
- This makes it easier to implement logic like: read -> timeout -> recovery -> back to read (on the same connection).

Proposal:
- Current implementation would make ws.Conn one-time use in nature, after any read error happened.
- New implementation would use SetReadDeadline to refresh conn.readErr/readErrCount, to reset connection read status.
