### PR TITLE
ss18/pr0, enhancement

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -22,18 +22,18 @@ func (fn netDialerFunc) Dial(network, addr string) (net.Conn, error) {
 
 func init() {
 	proxy_RegisterDialerType("http", func(proxyURL *url.URL, forwardDialer proxy_Dialer) (proxy_Dialer, error) {
-		return &httpProxyDialer{proxyURL: proxyURL, fowardDial: forwardDialer.Dial}, nil
+		return &httpProxyDialer{proxyURL: proxyURL, forwardDial: forwardDialer.Dial}, nil
 	})
 }
 
 type httpProxyDialer struct {
 	proxyURL   *url.URL
-	fowardDial func(network, addr string) (net.Conn, error)
+	forwardDial func(network, addr string) (net.Conn, error)
 }
 
 func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) {
 	hostPort, _ := hostPortNoPort(hpd.proxyURL)
-	conn, err := hpd.fowardDial(network, hostPort)
+	conn, err := hpd.forwardDial(network, hostPort)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixed typo:
foward -> forward (fowardDial -> forwardDial)

Found with: https://github.com/ss18/grep-typos