### PR TITLE
Expose newConn function

### DIFF
--- a/client.go
+++ b/client.go
@@ -324,7 +324,7 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 		}
 	}
 
-	conn := newConn(netConn, false, d.ReadBufferSize, d.WriteBufferSize, d.WriteBufferPool, nil, nil)
+	conn := NewConn(netConn, false, d.ReadBufferSize, d.WriteBufferSize, d.WriteBufferPool, nil, nil)
 
 	if err := req.Write(netConn); err != nil {
 		return nil, nil, err

--- a/conn.go
+++ b/conn.go
@@ -281,10 +281,6 @@ type Conn struct {
 
 // NewConn takes a net.Conn and wraps it with a websocket.Conn
 func NewConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int, writeBufferPool BufferPool, br *bufio.Reader, writeBuf []byte) *Conn {
-	return newConn(conn, isServer, readBufferSize, writeBufferSize, writeBufferPool, br, writeBuf)
-}
-
-func newConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int, writeBufferPool BufferPool, br *bufio.Reader, writeBuf []byte) *Conn {
 
 	if br == nil {
 		if readBufferSize == 0 {

--- a/conn.go
+++ b/conn.go
@@ -279,6 +279,11 @@ type Conn struct {
 	newDecompressionReader func(io.Reader) io.ReadCloser
 }
 
+// NewConn takes a net.Conn and wraps it with a websocket.Conn
+func NewConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int, writeBufferPool BufferPool, br *bufio.Reader, writeBuf []byte) *Conn {
+	return newConn(conn, isServer, readBufferSize, writeBufferSize, writeBufferPool, br, writeBuf)
+}
+
 func newConn(conn net.Conn, isServer bool, readBufferSize, writeBufferSize int, writeBufferPool BufferPool, br *bufio.Reader, writeBuf []byte) *Conn {
 
 	if br == nil {

--- a/server.go
+++ b/server.go
@@ -199,7 +199,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 		writeBuf = buf
 	}
 
-	c := newConn(netConn, true, u.ReadBufferSize, u.WriteBufferSize, u.WriteBufferPool, br, writeBuf)
+	c := NewConn(netConn, true, u.ReadBufferSize, u.WriteBufferSize, u.WriteBufferPool, br, writeBuf)
 	c.subprotocol = subprotocol
 
 	if compress {


### PR DESCRIPTION
Hi, 

Relatively new to the gorilla/websocket library but I have a use-case where I need to upgrade a net.Conn to a websocket.Conn, however there does not seem to be a builtin method of doing so directly (only indirectly through upgrading a ResponseWriter).  Would it be possible to expose the NewConn function as I have done in this PR or is there a better approach?  Any suggestions would be much appreciated!

Thanks!