### PR TITLE
Add warning to dial api about response cutoff

### DIFF
--- a/client.go
+++ b/client.go
@@ -102,6 +102,7 @@ type Dialer struct {
 }
 
 // Dial creates a new client connection by calling DialContext with a background context.
+// In the case of an error, only the first 1024 bytes of the response will be returned.
 func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
 	return d.DialContext(context.Background(), urlStr, requestHeader)
 }


### PR DESCRIPTION
It was a bit surprising to find out that only part of the response body was being returned, and I spent time digging around to find the culprit. I think it should at least be documented on the api call.  

Ideally though, it would just propagate the entire response body.