### PR TITLE
Make use of time.Until

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -418,7 +418,7 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 
 	d := time.Hour * 1000
 	if !deadline.IsZero() {
-		d = deadline.Sub(time.Now())
+		d = time.Until(deadline)
 		if d < 0 {
 			return errWriteTimeout
 		}


### PR DESCRIPTION
Use time.Until instead of manually subtracting timestamps.