### PR TITLE
Fix broadcast benchmarks

### DIFF
--- a/conn_broadcast_test.go
+++ b/conn_broadcast_test.go
@@ -18,7 +18,6 @@ import (
 // scenarios with many subscribers in one channel.
 type broadcastBench struct {
 	w           io.Writer
-	message     *broadcastMessage
 	closeCh     chan struct{}
 	doneCh      chan struct{}
 	count       int32
@@ -52,14 +51,6 @@ func newBroadcastBench(usePrepared, compression bool) *broadcastBench {
 		usePrepared: usePrepared,
 		compression: compression,
 	}
-	msg := &broadcastMessage{
-		payload: textMessages(1)[0],
-	}
-	if usePrepared {
-		pm, _ := NewPreparedMessage(TextMessage, msg.payload)
-		msg.prepared = pm
-	}
-	bench.message = msg
 	bench.makeConns(10000)
 	return bench
 }
@@ -78,7 +69,7 @@ func (b *broadcastBench) makeConns(numConns int) {
 			for {
 				select {
 				case msg := <-c.msgCh:
-					if b.usePrepared {
+					if msg.prepared != nil {
 						c.conn.WritePreparedMessage(msg.prepared)
 					} else {
 						c.conn.WriteMessage(TextMessage, msg.payload)
@@ -100,9 +91,9 @@ func (b *broadcastBench) close() {
 	close(b.closeCh)
 }
 
-func (b *broadcastBench) runOnce() {
+func (b *broadcastBench) runOnce(msg *broadcastMessage) {
 	for _, c := range b.conns {
-		c.msgCh <- b.message
+		c.msgCh <- msg
 	}
 	<-b.doneCh
 }
@@ -114,17 +105,25 @@ func BenchmarkBroadcast(b *testing.B) {
 		compression bool
 	}{
 		{"NoCompression", false, false},
-		{"WithCompression", false, true},
+		{"Compression", false, true},
 		{"NoCompressionPrepared", true, false},
-		{"WithCompressionPrepared", true, true},
+		{"CompressionPrepared", true, true},
 	}
+	payload := textMessages(1)[0]
 	for _, bm := range benchmarks {
 		b.Run(bm.name, func(b *testing.B) {
 			bench := newBroadcastBench(bm.usePrepared, bm.compression)
 			defer bench.close()
 			b.ResetTimer()
 			for i := 0; i < b.N; i++ {
-				bench.runOnce()
+				message := &broadcastMessage{
+					payload: payload,
+				}
+				if bench.usePrepared {
+					pm, _ := NewPreparedMessage(TextMessage, message.payload)
+					message.prepared = pm
+				}
+				bench.runOnce(message)
 			}
 			b.ReportAllocs()
 		})

--- a/conn_broadcast_test.go
+++ b/conn_broadcast_test.go
@@ -91,7 +91,7 @@ func (b *broadcastBench) close() {
 	close(b.closeCh)
 }
 
-func (b *broadcastBench) runOnce(msg *broadcastMessage) {
+func (b *broadcastBench) broadcastOnce(msg *broadcastMessage) {
 	for _, c := range b.conns {
 		c.msgCh <- msg
 	}
@@ -123,7 +123,7 @@ func BenchmarkBroadcast(b *testing.B) {
 					pm, _ := NewPreparedMessage(TextMessage, message.payload)
 					message.prepared = pm
 				}
-				bench.runOnce(message)
+				bench.broadcastOnce(message)
 			}
 			b.ReportAllocs()
 		})


### PR DESCRIPTION
This pull request fixes broadcast benchmarks.

Before:

```
BenchmarkBroadcast/NoCompression-4         	     159	   7825192 ns/op	      22 B/op	       0 allocs/op
BenchmarkBroadcast/WithCompression-4       	      67	  17692579 ns/op	 1192272 B/op	   30004 allocs/op
BenchmarkBroadcast/NoCompressionPrepared-4 	     136	   9620360 ns/op	     224 B/op	       1 allocs/op
BenchmarkBroadcast/WithCompressionPrepared-4         	     139	   9190567 ns/op	    8922 B/op	       2 allocs/op
```

After:

```
BenchmarkBroadcast/NoCompression-4                   148           8806814 ns/op              43 B/op          1 allocs/op
BenchmarkBroadcast/Compression-4                      64          17525206 ns/op         1157741 B/op      30002 allocs/op
BenchmarkBroadcast/NoCompressionPrepared-4           136           9424210 ns/op           11492 B/op         17 allocs/op
BenchmarkBroadcast/CompressionPrepared-4             134           9622622 ns/op           47631 B/op         21 allocs/op
```

There are actually 2 fixes.

1) Fixes wrong tests semantics. These tests must benchmark writing the same message to many connections to compare effect of using `PreparedMessage` in various conditions. But on every iteration of benchmark loop tests that work with `PreparedMessage` type must create PreparedMessage from scratch. Otherwise we see strange results almost without allocations in PreparedMessage scenarios.

2) Fixes broken indentation in console because of very long name of test. Now benchmark results are properly aligned.