### PR TITLE
do not leak response body in *httpProxyDialer.Dial

### DIFF
--- a/proxy.go
+++ b/proxy.go
@@ -67,6 +67,7 @@ func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) 
 		conn.Close()
 		return nil, err
 	}
+	resp.Body.Close()
 
 	if resp.StatusCode != 200 {
 		conn.Close()


### PR DESCRIPTION
https://golang.org/pkg/net/http/#ReadResponse says:

`Clients must call resp.Body.Close when finished reading resp.Body.`

Since the response is not used, it can be closed right away.