### PR TITLE
tidy and remove empty go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=


### PR DESCRIPTION
**Summary of Changes**

1. tidy and remove empty go.sum 

The go.sum included entries for v1.4.0 of this repo.
Running go mod tidy removes these lines (as expected),
so this commit removes the empty go.sum file entirely.
It is not required, only go.mod.

The go.sum was created in https://github.com/gorilla/websocket/pull/460,
but there are no notes about why the go.sum included these lines.

Note that having the go.sum did not seem to hurt anything, but
it was unneeded since there were no relevant entries in the file.