### PR TITLE
conn: add nil check to WritePreparedMessage

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -726,6 +726,10 @@ func (w *messageWriter) Close() error {
 
 // WritePreparedMessage writes prepared message into connection.
 func (c *Conn) WritePreparedMessage(pm *PreparedMessage) error {
+	if pm == nil {
+		// Do nothing with nil messages
+		return nil
+	}
 	frameType, frameData, err := pm.frame(prepareKey{
 		isServer:         c.isServer,
 		compress:         c.newCompressionWriter != nil && c.enableWriteCompression && isData(pm.messageType),

--- a/conn_test.go
+++ b/conn_test.go
@@ -694,3 +694,12 @@ func TestFailedConnectionReadPanic(t *testing.T) {
 	}
 	t.Fatal("should not get here")
 }
+
+func TestWriteNilPreparedMessage(t *testing.T) {
+	var connBuf bytes.Buffer
+	wc := newTestConn(nil, &connBuf, true)
+
+	if wc.WritePreparedMessage(nil) != nil {
+		t.Error("nil writes should do nothing")
+	}
+}


### PR DESCRIPTION
**Summary of Changes**

This PR adds a `nil` check to the input of `WritePreparedMessage`. If a `nil` is passed in, it simply returns with no error. I think this behavior is fairly straightforward to understand - if no message is to be sent, don't send anything.

It also adds a unit test for this new behavior.
