### PR TITLE
echo example: handle received messages as text, not HTML

### DIFF
--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -67,7 +67,7 @@ window.addEventListener("load", function(evt) {
 
     var print = function(message) {
         var d = document.createElement("div");
-        d.innerHTML = message;
+        d.textContent = message;
         output.appendChild(d);
     };
 


### PR DESCRIPTION
The `print` function adds text as `innerHTML`, but  the text is not HTML.  Use `textContent` instead.