### PR TITLE
Duration order consistency when multiplying number by time unit

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -429,7 +429,7 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 		maskBytes(key, 0, buf[6:])
 	}
 
-	d := time.Hour * 1000
+	d := 1000 * time.Hour
 	if !deadline.IsZero() {
 		d = deadline.Sub(time.Now())
 		if d < 0 {


### PR DESCRIPTION
Fixes #

**Summary of Changes**

1. Fixed duration order consistency when multiplying number by time unit in conn.go
