### PR TITLE
Add method for checking if the buffer is empty

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1005,11 +1005,7 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 }
 
 func (c *Conn) IsBufferEmpty() bool {
-	if c.br.Buffered() > 0 {
-		return false
-	}
-
-	return true
+	return c.br.Buffered() == 0 
 }
 
 type messageReader struct{ c *Conn }

--- a/conn.go
+++ b/conn.go
@@ -1004,6 +1004,14 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 	return noFrame, nil, c.readErr
 }
 
+func (c *Conn) IsBufferEmpty() bool {
+	if c.br.Buffered() > 0 {
+		return false
+	}
+
+	return true
+}
+
 type messageReader struct{ c *Conn }
 
 func (r *messageReader) Read(b []byte) (int, error) {


### PR DESCRIPTION
Added #

**Summary of Changes**

just one method is added.

1. **IsBufferEmpty** is checking buffer before calling ReadMessage()

details,
If you are using this method, you can choose read more or not after calling ReadMessage(). I know, It is needed for [special case](https://stackoverflow.com/questions/60637676/is-there-a-way-to-check-read-buffer-is-remaining?noredirect=1#comment107283103_60637676).

I'm using this framework with epoll. but epoll event is not enough to read all packets even though it is level triggered. because once ReadMessage() is called, it reads more than 1 packet to bufio buffer from fd. 
So I needed to check "should I call ReadMessage one more?" this method gives me the solution.

If you want to reject this, what about adding the function wrapper of c.br.Buffered()?