### PR TITLE
build: clean up go.sum

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -1,2 +1,0 @@
-github.com/gorilla/websocket v1.4.0 h1:WDFjx/TMzVgy9VdMMQi2K2Emtwi2QcUQsztZ/zLaH/Q=
-github.com/gorilla/websocket v1.4.0/go.mod h1:E7qHFY5m1UJ88s3WnNqhKjPHQ0heANvMoAMk2YaljkQ=


### PR DESCRIPTION
Prep for v1.4.2.

* Ran `go mod tidy` - an empty `go.sum` is valid here and intended as we don't have non-stdlib dependencies.