### PR TITLE
Fix Manually passed `Cookie` header overrides `http.CookieJar` cookies

### DIFF
--- a/client.go
+++ b/client.go
@@ -186,13 +186,6 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 	}
 	req = req.WithContext(ctx)
 
-	// Set the cookies present in the cookie jar of the dialer
-	if d.Jar != nil {
-		for _, cookie := range d.Jar.Cookies(u) {
-			req.AddCookie(cookie)
-		}
-	}
-
 	// Set the request headers using the capitalization for names and values in
 	// RFC examples. Although the capitalization shouldn't matter, there are
 	// servers that depend on it. The Header.Set method is not used because the
@@ -221,6 +214,13 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 			req.Header["Sec-WebSocket-Protocol"] = vs
 		default:
 			req.Header[k] = vs
+		}
+	}
+
+	// Set the cookies present in the cookie jar of the dialer
+	if d.Jar != nil {
+		for _, cookie := range d.Jar.Cookies(u) {
+			req.AddCookie(cookie)
 		}
 	}
 


### PR DESCRIPTION
see [issue](https://github.com/gorilla/websocket/issues/597)
