### PR TITLE
Improve client documentation

### DIFF
--- a/client.go
+++ b/client.go
@@ -146,6 +146,9 @@ var nilDialer = *DefaultDialer
 // non-nil *http.Response so that callers can handle redirects, authentication,
 // etcetera. The response body may not contain the entire response and does not
 // need to be closed by the application.
+//
+// Note:Both Dialer.Subprotocols and requestHeader support the filling of subprotocol.
+// Please choose one of them according to the actual needs.
 func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
 	if d == nil {
 		d = &nilDialer


### PR DESCRIPTION

Note: Both Dialer.Subprotocols and requestHeader support the filling of sub-protocols. Please choose one of them according to the actual needs.
