### PR TITLE
json messages in chat example

### DIFF
--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -28,32 +28,42 @@ instance of the `Hub` type. The `Hub` maintains a set of registered clients and
 broadcasts messages to the clients.
 
 The application runs one goroutine for the `Hub` and two goroutines for each
-`Client`. The goroutines communicate with each other using channels. The `Hub`
-has channels for registering clients, unregistering clients and broadcasting
-messages. A `Client` has a buffered channel of outbound messages. One of the
-client's goroutines reads messages from this channel and writes the messages to
-the websocket. The other client goroutine reads json messages from the websocket 
-and sends them to the hub.
+`Client`. The application ensures that there is at most one reader and writer on
+a connection by executing all reads and writes for a client on a separate goroutine. 
+This is because Gorilla websocket connections support at most one concurrent reader
+and one concurrent writer. The goroutines communicate with each other using channels. 
+The `Hub` has channels for registering clients, unregistering clients, and broadcasting
+messages. 
+
+A `Client` has a buffered channel of outbound messages which accepts messages of type 
+`Message`. The `Message` type is a struct that represents a JSON message sent by a client. 
+It contains one field representing the `Body` of the message. The Gorilla websocket library
+does not enforce the datatype used to communicate between the client and the server. 
+However, JSON is one of the most commonly used data-interchange formats and was chosen
+for the purposes of this example.
 
 ### Hub 
 
 The code for the `Hub` type is in
 [hub.go](https://github.com/gorilla/websocket/blob/master/examples/chat/hub.go). 
 The application's `main` function starts the hub's `run` method as a goroutine.
-Clients send requests to the hub using the `register`, `unregister` and
+Clients send requests to the hub using the `register`, `unregister`, and
 `broadcast` channels.
 
 The hub registers clients by adding the client pointer as a key in the
 `clients` map. The map value is always true.
 
 The unregister code is a little more complicated. In addition to deleting the
-client pointer from the `clients` map, the hub closes the clients's `send`
+client pointer from the `clients` map, the hub closes the client's `send`
 channel to signal the client that no more messages will be sent to the client.
 
-The hub handles messages by looping over the registered clients and sending the
-json marshalled message to the client's `send` channel. If the client's `send` 
-buffer is full, then the hub assumes that the client is dead or stuck. In this 
-case, the hub unregisters the client and closes the websocket.
+When a client's `readPump` method sends a message to the hub's broadcast channel, 
+the hub must broadcast this message to all clients on the websocket connection. 
+The hub handles this by looping over the registered clients, marshalling the `Message` 
+into JSON, and sending it to each client's `send` channel. Writing the message to
+the websocket is then handled by each client's `writePump` goroutine. If the
+client's `send` buffer is full, then the hub assumes that the client is dead or
+stuck. In this case, the hub unregisters the client and closes the websocket.
 
 ### Client
 
@@ -61,7 +71,7 @@ The code for the `Client` type is in [client.go](https://github.com/gorilla/webs
 
 The `serveWs` function is registered by the application's `main` function as
 an HTTP handler. The handler upgrades the HTTP connection to the WebSocket
-protocol, creates a client, registers the client with the hub and schedules the
+protocol, creates a client, registers the client with the hub, and schedules the
 client to be unregistered using a defer statement.
 
 Next, the HTTP handler starts the client's `writePump` method as a goroutine.
@@ -70,7 +80,8 @@ connection. The writer method exits when the channel is closed by the hub or
 there's an error writing to the websocket connection.
 
 Finally, the HTTP handler calls the client's `readPump` method. This method
-transfers inbound messages from the websocket to the hub.
+decodes client messages into the `Message` type, and sends them to the hub's 
+broadcast channel.
 
 WebSocket connections [support one concurrent reader and one concurrent
 writer](https://godoc.org/github.com/gorilla/websocket#hdr-Concurrency). The
@@ -98,5 +109,6 @@ adding new content. If the chat log is scrolled to the bottom, then the
 function scrolls new content into view after adding the content. Otherwise, the
 scroll position is not changed.
 
-The form handler writes the user input to the websocket and clears the input
-field.
+The form handler stringifies user input into the JSON corresponding to the server's 
+`Message` type: `{ body: msg }`. It sends this message to the websocket and clears
+the input field.

--- a/examples/chat/README.md
+++ b/examples/chat/README.md
@@ -32,8 +32,8 @@ The application runs one goroutine for the `Hub` and two goroutines for each
 has channels for registering clients, unregistering clients and broadcasting
 messages. A `Client` has a buffered channel of outbound messages. One of the
 client's goroutines reads messages from this channel and writes the messages to
-the websocket. The other client goroutine reads messages from the websocket and
-sends them to the hub.
+the websocket. The other client goroutine reads json messages from the websocket 
+and sends them to the hub.
 
 ### Hub 
 
@@ -51,9 +51,9 @@ client pointer from the `clients` map, the hub closes the clients's `send`
 channel to signal the client that no more messages will be sent to the client.
 
 The hub handles messages by looping over the registered clients and sending the
-message to the client's `send` channel. If the client's `send` buffer is full,
-then the hub assumes that the client is dead or stuck. In this case, the hub
-unregisters the client and closes the websocket.
+json marshalled message to the client's `send` channel. If the client's `send` 
+buffer is full, then the hub assumes that the client is dead or stuck. In this 
+case, the hub unregisters the client and closes the websocket.
 
 ### Client
 

--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -5,11 +5,9 @@
 package main
 
 import (
-	"bytes"
-	"encoding/json"
-	"fmt"
 	"log"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/gorilla/websocket"
@@ -30,8 +28,8 @@ const (
 )
 
 var (
-	newline = []byte{'\n'}
-	space   = []byte{' '}
+	newline = "\n"
+	space   = " "
 )
 
 var upgrader = websocket.Upgrader{
@@ -78,15 +76,11 @@ func (c *Client) readPump() {
 			}
 			break
 		}
+		message.Body = strings.TrimSpace(strings.Replace(message.Body, newline, space, -1))
 		// The message sent by the client is now decoded into the message variable
 		// This is when you can perform database calls, validations, or other logic
 		// db.Insert(...)
-		data, err := json.Marshal(message)
-		if err != nil {
-			log.Print(fmt.Sprint("Error while marshalling message:", err))
-		}
-		data = bytes.TrimSpace(bytes.Replace(data, newline, space, -1))
-		c.hub.broadcast <- data
+		c.hub.broadcast <- message
 	}
 }
 
@@ -120,7 +114,7 @@ func (c *Client) writePump() {
 			// Add queued chat messages to the current websocket message.
 			n := len(c.send)
 			for i := 0; i < n; i++ {
-				w.Write(newline)
+				w.Write([]byte{' '})
 				w.Write(<-c.send)
 			}
 

--- a/examples/chat/client.go
+++ b/examples/chat/client.go
@@ -114,7 +114,7 @@ func (c *Client) writePump() {
 			// Add queued chat messages to the current websocket message.
 			n := len(c.send)
 			for i := 0; i < n; i++ {
-				w.Write([]byte{' '})
+				w.Write([]byte(newline))
 				w.Write(<-c.send)
 			}
 

--- a/examples/chat/home.html
+++ b/examples/chat/home.html
@@ -23,7 +23,7 @@ window.onload = function () {
         if (!msg.value) {
             return false;
         }
-        conn.send(msg.value);
+        conn.send(JSON.stringify({ body: msg.value }));
         msg.value = "";
         return false;
     };
@@ -36,7 +36,7 @@ window.onload = function () {
             appendLog(item);
         };
         conn.onmessage = function (evt) {
-            var messages = evt.data.split('\n');
+            var messages = JSON.parse(evt.data).body.split('\n');
             for (var i = 0; i < messages.length; i++) {
                 var item = document.createElement("div");
                 item.innerText = messages[i];


### PR DESCRIPTION
Most people using this library will probably me sending JSON data through websockets if they want to store any meaningful data in messages or perform other logic, so I update the chat example to handle JSON data.

Summary of changes:

client.go: 
- Add `Message` struct type.
- Use `ReadJSON` instead of `ReadMessage`.
- Update message trimming logic to handle message body strings instead of byte arrays

hub.go:
- Convert broadcast channel from byte array to `Message` struct type
- `JSON.Marshal` message struct before sending to client

home.html:
- Send stringified json message on form submit
- Parse `onmessage` event data into json