### PR TITLE
Fix examples / command: kill runned process onclose

### DIFF
--- a/examples/command/main.go
+++ b/examples/command/main.go
@@ -132,6 +132,7 @@ func serveWs(w http.ResponseWriter, r *http.Request) {
 		internalError(ws, "start:", err)
 		return
 	}
+	defer proc.Kill()
 
 	inr.Close()
 	outw.Close()


### PR DESCRIPTION
After closing browser tab, or refresh tab, or when example is shooting down, child process may still be running. So I suggest to add defer proc.Kill()

It can happen when example running long time working program, or interactive program.

Fixes #

**Summary of Changes**

1. add `defer proc.Kill()` after `os.StartProcess(...)`
