### PR TITLE
Static analysis : gosec high issue : G402 : TLS MinVersion too low.

### DIFF
--- a/client_clone.go
+++ b/client_clone.go
@@ -10,7 +10,9 @@ import "crypto/tls"
 
 func cloneTLSConfig(cfg *tls.Config) *tls.Config {
 	if cfg == nil {
-		return &tls.Config{}
+		return &tls.Config{
+			MinVersion: tls.VersionTLS12
+		}
 	}
 	return cfg.Clone()
 }

--- a/client_clone.go
+++ b/client_clone.go
@@ -11,7 +11,7 @@ import "crypto/tls"
 func cloneTLSConfig(cfg *tls.Config) *tls.Config {
 	if cfg == nil {
 		return &tls.Config{
-			MinVersion: tls.VersionTLS12
+			MinVersion: tls.VersionTLS12,
 		}
 	}
 	return cfg.Clone()


### PR DESCRIPTION
# Issue: 
**$ for mod in $(find . -name go.mod); do gosec -quiet -confidence high -severity high $(dirname $mod) || rc=1 ; done**
Results:
[github.com/gorilla/websocket/client_clone.go:13] - G402 (CWE-295): TLS MinVersion too low. (Confidence: HIGH, Severity: HIGH)
    12: 	if cfg == nil {
   13: 		return &tls.Config{}
    14: 	}
Summary:
  Gosec  : dev
  Files  : 15
  Lines  : 3475
  Nosec  : 0
  Issues : 1