### PR TITLE
fixed to use context.Context in TLS handshake

### DIFF
--- a/client.go
+++ b/client.go
@@ -314,9 +314,9 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 
 		var err error
 		if trace != nil {
-			err = doHandshakeWithTrace(trace, tlsConn, cfg)
+			err = doHandshakeWithTrace(ctx, trace, tlsConn, cfg)
 		} else {
-			err = doHandshake(tlsConn, cfg)
+			err = doHandshake(ctx, tlsConn, cfg)
 		}
 
 		if err != nil {
@@ -380,16 +380,4 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 	netConn.SetDeadline(time.Time{})
 	netConn = nil // to avoid close in defer.
 	return conn, resp, nil
-}
-
-func doHandshake(tlsConn *tls.Conn, cfg *tls.Config) error {
-	if err := tlsConn.Handshake(); err != nil {
-		return err
-	}
-	if !cfg.InsecureSkipVerify {
-		if err := tlsConn.VerifyHostname(cfg.ServerName); err != nil {
-			return err
-		}
-	}
-	return nil
 }

--- a/tls_handshake.go
+++ b/tls_handshake.go
@@ -1,0 +1,21 @@
+//go:build go1.17
+// +build go1.17
+
+package websocket
+
+import (
+	"context"
+	"crypto/tls"
+)
+
+func doHandshake(ctx context.Context, tlsConn *tls.Conn, cfg *tls.Config) error {
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		return err
+	}
+	if !cfg.InsecureSkipVerify {
+		if err := tlsConn.VerifyHostname(cfg.ServerName); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/tls_handshake_116.go
+++ b/tls_handshake_116.go
@@ -1,0 +1,21 @@
+//go:build !go1.17
+// +build !go1.17
+
+package websocket
+
+import (
+	"context"
+	"crypto/tls"
+)
+
+func doHandshake(ctx context.Context, tlsConn *tls.Conn, cfg *tls.Config) error {
+	if err := tlsConn.Handshake(); err != nil {
+		return err
+	}
+	if !cfg.InsecureSkipVerify {
+		if err := tlsConn.VerifyHostname(cfg.ServerName); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/trace.go
+++ b/trace.go
@@ -1,17 +1,19 @@
+//go:build go1.8
 // +build go1.8
 
 package websocket
 
 import (
+	"context"
 	"crypto/tls"
 	"net/http/httptrace"
 )
 
-func doHandshakeWithTrace(trace *httptrace.ClientTrace, tlsConn *tls.Conn, cfg *tls.Config) error {
+func doHandshakeWithTrace(ctx context.Context, trace *httptrace.ClientTrace, tlsConn *tls.Conn, cfg *tls.Config) error {
 	if trace.TLSHandshakeStart != nil {
 		trace.TLSHandshakeStart()
 	}
-	err := doHandshake(tlsConn, cfg)
+	err := doHandshake(ctx, tlsConn, cfg)
 	if trace.TLSHandshakeDone != nil {
 		trace.TLSHandshakeDone(tlsConn.ConnectionState(), err)
 	}

--- a/trace_17.go
+++ b/trace_17.go
@@ -1,3 +1,4 @@
+//go:build !go1.8
 // +build !go1.8
 
 package websocket
@@ -7,6 +8,6 @@ import (
 	"net/http/httptrace"
 )
 
-func doHandshakeWithTrace(trace *httptrace.ClientTrace, tlsConn *tls.Conn, cfg *tls.Config) error {
-	return doHandshake(tlsConn, cfg)
+func doHandshakeWithTrace(ctx context.Context, trace *httptrace.ClientTrace, tlsConn *tls.Conn, cfg *tls.Config) error {
+	return doHandshake(ctx, tlsConn, cfg)
 }


### PR DESCRIPTION
Relate to https://github.com/golang/go/issues/32406

**Summary of Changes**

- I fixed to allow canceling of timeouts and other events using context during TLS Handshake.
  - https://pkg.go.dev/crypto/tls#Conn.HandshakeContext
- As the link says, Go Team has a migration plan for [build constraints](https://tip.golang.org/doc/go1.17#:~:text=mod%20download%20all.-,//go%3Abuild%20lines,-The%20go%20command). So I fixed it so that it is supported by auto-generation.
