### PR TITLE
Tls proxy

### DIFF
--- a/client.go
+++ b/client.go
@@ -274,6 +274,14 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 			return nil, nil, err
 		}
 		if proxyURL != nil {
+			if proxyURL.Scheme == "https" {
+				netDial = func(network, addr string) (net.Conn, error) {
+					t := tls.Dialer{}
+					t.Config = d.TLSClientConfig
+					t.NetDialer = &net.Dialer{}
+					return t.DialContext(ctx, network, addr)
+				}
+			}
 			dialer, err := proxy_FromURL(proxyURL, netDialerFunc(netDial))
 			if err != nil {
 				return nil, nil, err

--- a/client.go
+++ b/client.go
@@ -274,15 +274,17 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 			return nil, nil, err
 		}
 		if proxyURL != nil {
+			proxyDialer := &netDialerFunc{fn: netDial}
 			if proxyURL.Scheme == "https" {
-				netDial = func(network, addr string) (net.Conn, error) {
+				proxyDialer.usesTLS = true
+				proxyDialer.fn = func(network, addr string) (net.Conn, error) {
 					t := tls.Dialer{}
 					t.Config = d.TLSClientConfig
 					t.NetDialer = &net.Dialer{}
 					return t.DialContext(ctx, network, addr)
 				}
 			}
-			dialer, err := proxy_FromURL(proxyURL, netDialerFunc(netDial))
+			dialer, err := proxy_FromURL(proxyURL, proxyDialer)
 			if err != nil {
 				return nil, nil, err
 			}

--- a/proxy.go
+++ b/proxy.go
@@ -6,7 +6,6 @@ package websocket
 
 import (
 	"bufio"
-	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"net"
@@ -21,20 +20,12 @@ func (fn netDialerFunc) Dial(network, addr string) (net.Conn, error) {
 	return fn(network, addr)
 }
 
-type tlsDialer struct {
-}
-
-func (t *tlsDialer) Dial(network, addr string) (c net.Conn, err error) {
-	return tls.DialWithDialer(&net.Dialer{}, network, addr, &tls.Config{})
-}
-
 func init() {
 	proxy_RegisterDialerType("http", func(proxyURL *url.URL, forwardDialer proxy_Dialer) (proxy_Dialer, error) {
 		return &httpProxyDialer{proxyURL: proxyURL, forwardDial: forwardDialer.Dial}, nil
 	})
 	proxy_RegisterDialerType("https", func(proxyURL *url.URL, forwardDialer proxy_Dialer) (proxy_Dialer, error) {
-		dialer := &tlsDialer{}
-		return &httpProxyDialer{proxyURL: proxyURL, forwardDial: dialer.Dial}, nil
+		return &httpProxyDialer{proxyURL: proxyURL, forwardDial: forwardDialer.Dial}, nil
 	})
 }
 

--- a/proxy.go
+++ b/proxy.go
@@ -6,6 +6,7 @@ package websocket
 
 import (
 	"bufio"
+	"crypto/tls"
 	"encoding/base64"
 	"errors"
 	"net"
@@ -20,9 +21,20 @@ func (fn netDialerFunc) Dial(network, addr string) (net.Conn, error) {
 	return fn(network, addr)
 }
 
+type tlsDialer struct {
+}
+
+func (t *tlsDialer) Dial(network, addr string) (c net.Conn, err error) {
+	return tls.DialWithDialer(&net.Dialer{}, network, addr, &tls.Config{})
+}
+
 func init() {
 	proxy_RegisterDialerType("http", func(proxyURL *url.URL, forwardDialer proxy_Dialer) (proxy_Dialer, error) {
 		return &httpProxyDialer{proxyURL: proxyURL, forwardDial: forwardDialer.Dial}, nil
+	})
+	proxy_RegisterDialerType("https", func(proxyURL *url.URL, forwardDialer proxy_Dialer) (proxy_Dialer, error) {
+		dialer := &tlsDialer{}
+		return &httpProxyDialer{proxyURL: proxyURL, forwardDial: dialer.Dial}, nil
 	})
 }
 

--- a/x_net_proxy.go
+++ b/x_net_proxy.go
@@ -27,6 +27,10 @@ func (proxy_direct) Dial(network, addr string) (net.Conn, error) {
 	return net.Dial(network, addr)
 }
 
+func (proxy_direct) UsesTLS() bool {
+	return false
+}
+
 // A PerHost directs connections to a default Dialer unless the host name
 // requested matches one of a number of exceptions.
 type proxy_PerHost struct {
@@ -57,6 +61,10 @@ func (p *proxy_PerHost) Dial(network, addr string) (c net.Conn, err error) {
 	}
 
 	return p.dialerForRequest(host).Dial(network, addr)
+}
+
+func (p *proxy_PerHost) UsesTLS() bool {
+	return p.def.UsesTLS() || p.bypass.UsesTLS()
 }
 
 func (p *proxy_PerHost) dialerForRequest(host string) proxy_Dialer {
@@ -161,6 +169,8 @@ func (p *proxy_PerHost) AddHost(host string) {
 type proxy_Dialer interface {
 	// Dial connects to the given address via the proxy.
 	Dial(network, addr string) (c net.Conn, err error)
+	// UsesTLS indicates whether we expect to dial to a TLS proxy
+	UsesTLS() bool
 }
 
 // Auth contains authentication parameters that specific Dialers may require.
@@ -336,6 +346,10 @@ func (s *proxy_socks5) Dial(network, addr string) (net.Conn, error) {
 		return nil, err
 	}
 	return conn, nil
+}
+
+func (s *proxy_socks5) UsesTLS() bool {
+	return s.forward.UsesTLS()
 }
 
 // connect takes an existing connection to a socks5 proxy server,


### PR DESCRIPTION
Fixes #739 

**Summary of Changes**

1. call `proxy_RegisterDialerType` for the `https` scheme to allow communication to https proxies
2. some scheme-specific setup is necessary in Dialer's DialContext in order to use the TLSClientConfig
3. add a `UsesTLS` method to the `proxy_Dialer` interface to ensure the https forwardDialer can inspect that https is supported, and to adjust if necessary

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
