### PR TITLE
Changed the method name UnderlyingConn to NetConn

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1189,8 +1189,16 @@ func (c *Conn) SetPongHandler(h func(appData string) error) {
 	c.handlePong = h
 }
 
+// NetConn returns the underlying connection that is wrapped by c.
+// Note that writing to or reading from this connection directly will corrupt the
+// WebSocket connection.
+func (c *Conn) NetConn() net.Conn {
+	return c.conn
+}
+
 // UnderlyingConn returns the internal net.Conn. This can be used to further
 // modifications to connection specific flags.
+// Deprecated: Use the NetConn method.
 func (c *Conn) UnderlyingConn() net.Conn {
 	return c.conn
 }

--- a/conn_test.go
+++ b/conn_test.go
@@ -562,11 +562,21 @@ func TestAddrs(t *testing.T) {
 	}
 }
 
-func TestUnderlyingConn(t *testing.T) {
+func TestDeprecatedUnderlyingConn(t *testing.T) {
 	var b1, b2 bytes.Buffer
 	fc := fakeNetConn{Reader: &b1, Writer: &b2}
 	c := newConn(fc, true, 1024, 1024, nil, nil, nil)
 	ul := c.UnderlyingConn()
+	if ul != fc {
+		t.Fatalf("Underlying conn is not what it should be.")
+	}
+}
+
+func TestNetConn(t *testing.T) {
+	var b1, b2 bytes.Buffer
+	fc := fakeNetConn{Reader: &b1, Writer: &b2}
+	c := newConn(fc, true, 1024, 1024, nil, nil, nil)
+	ul := c.NetConn()
 	if ul != fc {
 		t.Fatalf("Underlying conn is not what it should be.")
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -111,7 +111,7 @@ func TestBufioReuse(t *testing.T) {
 		if reuse := c.br == br; reuse != tt.reuse {
 			t.Errorf("%d: buffered reader reuse=%v, want %v", i, reuse, tt.reuse)
 		}
-		writeBuf := bufioWriterBuffer(c.UnderlyingConn(), bw)
+		writeBuf := bufioWriterBuffer(c.NetConn(), bw)
 		if reuse := &c.writeBuf[0] == &writeBuf[0]; reuse != tt.reuse {
 			t.Errorf("%d: write buffer reuse=%v, want %v", i, reuse, tt.reuse)
 		}


### PR DESCRIPTION
Fixes #766

**Summary of Changes**

1. Changed the method name `UnderlyingConn` to `NetConn` and marked `UnderlyingConn` as deprecated
2. Changed the test name to `TestDeprecatedUnderlyingConn`
3. Added new test `TestNetConn` to test `NetConn` method