### PR TITLE
Edit the Go version in go.mod file in order to solve a compile error on the editor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
 module github.com/gorilla/websocket
 
-go 1.12
+go 1.13


### PR DESCRIPTION
Fixes: No related to any issue (I'm sorry to skip creating a new issue 🙇 )

**Summary of Changes**

1. Just edit the Go version in go.mod file in order to solve a compile error on the editor on conn.go.

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!

**Background**

A compile error is showed on `conn.go` on my Visual Studio Code.

```go
return [4]byte{byte(n), byte(n >> 8), byte(n >> 16), byte(n >> 24)}
```

> invalid operation: signed shift count 8 (untyped int constant) requires go1.13 or later compilerInvalidShiftCount

The unexported function `newMaskKey` was added 4 years ago.
https://github.com/gorilla/websocket/issues/200

However, signed shift counts was restricted before Go 1.13.

> Per the signed shift counts proposal Go 1.13 removes the restriction that a shift count must be unsigned.
https://go.dev/doc/go1.13

It's not affected the behaviour but it's better to mark the Go version is Go 1.13 or later.