### PR TITLE
Add optional method ProxyTLSConnection (closes #779)

### DIFF
--- a/client.go
+++ b/client.go
@@ -65,6 +65,12 @@ type Dialer struct {
 	// TLSClientConfig is ignored.
 	NetDialTLSContext func(ctx context.Context, network, addr string) (net.Conn, error)
 
+	// ProxyTLSConnection specifies the dial function for creating TLS connections through a Proxy. If
+	// ProxyTLSConnection is nil, NetDialTLSContext is used.
+	// If ProxyTLSConnection is set, Dial assumes the TLS handshake is done there and
+	// TLSClientConfig is ignored.
+	ProxyTLSConnection func(ctx context.Context, proxyConn net.Conn) (net.Conn, error)
+
 	// Proxy specifies a function to return a proxy for a given
 	// Request. If the function returns a non-nil error, the
 	// request is aborted with the provided error.
@@ -333,26 +339,31 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 		}
 	}()
 
-	if u.Scheme == "https" && d.NetDialTLSContext == nil {
-		// If NetDialTLSContext is set, assume that the TLS handshake has already been done
+	if u.Scheme == "https" {
+		if d.ProxyTLSConnection != nil && d.Proxy != nil {
+			// If we are connected to a proxy, perform the TLS handshake through the existing tunnel
+			netConn, err = d.ProxyTLSConnection(ctx, netConn)
+		} else if d.NetDialTLSContext == nil {
+			// If NetDialTLSContext is set, assume that the TLS handshake has already been done
 
-		cfg := cloneTLSConfig(d.TLSClientConfig)
-		if cfg.ServerName == "" {
-			cfg.ServerName = hostNoPort
-		}
-		tlsConn := tls.Client(netConn, cfg)
-		netConn = tlsConn
+			cfg := cloneTLSConfig(d.TLSClientConfig)
+			if cfg.ServerName == "" {
+				cfg.ServerName = hostNoPort
+			}
+			tlsConn := tls.Client(netConn, cfg)
+			netConn = tlsConn
 
-		if trace != nil && trace.TLSHandshakeStart != nil {
-			trace.TLSHandshakeStart()
-		}
-		err := doHandshake(ctx, tlsConn, cfg)
-		if trace != nil && trace.TLSHandshakeDone != nil {
-			trace.TLSHandshakeDone(tlsConn.ConnectionState(), err)
-		}
+			if trace != nil && trace.TLSHandshakeStart != nil {
+				trace.TLSHandshakeStart()
+			}
+			err := doHandshake(ctx, tlsConn, cfg)
+			if trace != nil && trace.TLSHandshakeDone != nil {
+				trace.TLSHandshakeDone(tlsConn.ConnectionState(), err)
+			}
 
-		if err != nil {
-			return nil, nil, err
+			if err != nil {
+				return nil, nil, err
+			}
 		}
 	}
 

--- a/proxy.go
+++ b/proxy.go
@@ -33,7 +33,7 @@ type httpProxyDialer struct {
 
 func (hpd *httpProxyDialer) Dial(network string, addr string) (net.Conn, error) {
 	hostPort, _ := hostPortNoPort(hpd.proxyURL)
-	conn, err := hpd.forwardDial(network, hostPort)
+	conn, err := net.Dial(network, hostPort)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, it was impossible to specify both `Proxy` and `NetDialTLSContext` on the websocket `Dialer` without experiencing connection issues. This commit brings a change to the proxy CONNECT flow so that the initial connection is always a normal proxy CONNECT over TCP, while allowing TLS customizations on the existing connection at a later point in time via the new `ProxyTLSConnection` method.

Fixes #779

**Summary of Changes**

Please see my comment on the relevant issue for a detailed explanation and my thought process: https://github.com/gorilla/websocket/issues/779#issuecomment-1125185896

Tests are **not included**, I'd appreciate some help or guidance on that front because I'm unsure what to test, thanks!