### PR TITLE
remove all versions < 1.16 and add 1.18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,8 +16,8 @@ jobs:
         type: string
         default: ""
     docker:
-      - image: "circleci/golang:<< parameters.version >>"
-    working_directory: /go/src/github.com/gorilla/websocket
+      - image: "cimg/go:<< parameters.version >>"
+    working_directory: /home/circleci/project/go/src/github.com/gorilla/websocket
     environment:
       GO111MODULE: "on"
       GOPROXY: "<< parameters.goproxy >>"
@@ -67,4 +67,4 @@ workflows:
       - test:
           matrix:
             parameters:
-              version: ["latest", "1.17", "1.16", "1.15", "1.14", "1.13", "1.12", "1.11"]
+              version: ["1.18", "1.17", "1.16"]


### PR DESCRIPTION
Fixes #792

**Summary of Changes**
all within `.circleci/config.yml`:
1. point the image field to the new image URL.
2. fix the working directory (the old working directory no longer works against the new image).
3. drop go versions that are no longer supported + add 1.18

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!
