### PR TITLE
Feature # support client send msg before handshake is completed 

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -10,7 +10,6 @@ import (
 	"net/http"
 	"net/url"
 	"testing"
-	"time"
 )
 
 var hostPortNoPortTests = []struct {
@@ -44,13 +43,13 @@ func TestWsServer(t *testing.T) {
 			fmt.Println("err upgrade", err)
 			return
 		}
+		defer conn.Close()
 		_, msg, err := conn.ReadMessage()
 		if err != nil {
 			fmt.Println("err read message", err)
 			return
 		}
 		conn.WriteMessage(TextMessage, []byte("hello world response："+string(msg)))
-		time.Sleep(1 * time.Second)
 	})
 	http.ListenAndServe(":8888", nil)
 }
@@ -64,7 +63,7 @@ func TestAsyncDial(t *testing.T) {
 
 	err = conn.AsyncWait()
 	if err != nil {
-		//panic(err)
+		panic(err)
 	}
 
 	for {

--- a/example_test.go
+++ b/example_test.go
@@ -5,11 +5,10 @@
 package websocket_test
 
 import (
+	"github.com/gorilla/websocket"
 	"log"
 	"net/http"
 	"testing"
-
-	"github.com/gorilla/websocket"
 )
 
 var (

--- a/mergedConn.go
+++ b/mergedConn.go
@@ -1,0 +1,26 @@
+package websocket
+
+import (
+	"net"
+)
+
+type mergedConnReader struct {
+	net.Conn
+	unread []byte
+}
+
+func newMergedNetConnReader(conn net.Conn, unread []byte) net.Conn {
+	return &mergedConnReader{
+		Conn:   conn,
+		unread: unread,
+	}
+}
+
+func (m *mergedConnReader) Read(b []byte) (n int, err error) {
+	if len(m.unread) > 0 {
+		n = copy(b, m.unread)
+		m.unread = m.unread[n:]
+		return n, nil
+	}
+	return m.Conn.Read(b)
+}


### PR DESCRIPTION
Feature #
Some times ,we want client  can send message before handshake is completed to accelerate request . But this websocket lib seems does not support it. So this pull request contains code  that can make the lib support it.
**Summary of Changes**

1. Add func DialContextAsync to support client get websocket conn  before 101 returned ,to support client send pre message.
2. Add func AsyncWait to support client wait until 101 returned to avoid read bad websocket frame before 101 returned . 
3.   Make server support  client send message before handshake is completed
4. Some tests to test the changes

> PS: Make sure your PR includes/updates tests! If you need help with this part, just ask!