### PR TITLE
Cleanup remnants of net.Error Temporary()

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -18,8 +18,6 @@ import (
 	"time"
 )
 
-var _ net.Error = errWriteTimeout
-
 type fakeNetConn struct {
 	io.Reader
 	io.Writer


### PR DESCRIPTION
A previous change to the package removed calls to the deprecated net.Error Temporary() method. This change removes the cruft left behind by that change.

- Delete the hideTempError function. Because applications should not call net.Error Temporary() method, there's no need to force the Temporary() return value to false. 

- Replace the internal errWriteTimeout error with the standard os.ErrDeadlineExceeded.

- Prior to the removing the calls to Temporary(), the default ping and close handlers ignored timeout errors by checking for net.Error Temporary() == true. The current code does not ignore timeout errors. Restore the code to ignore timeout errors by checking for os.ErrDeadlineExceeded.

Unrelated to the above: Reduce noise in the test output by ignoring the error from the compress/flate reader Close method.