### PR TITLE
Do not handle network error in `SetCloseHandler()`

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1159,8 +1159,12 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
 			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
-			if err != nil && err != ErrCloseSent {
-				return err
+			if err != nil {
+				if _, ok := err.(net.Error); ok {
+					return nil
+				} else if err != ErrCloseSent {
+					return err
+				}
 			}
 			return nil
 		}

--- a/conn.go
+++ b/conn.go
@@ -1158,14 +1158,7 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
-			if err != nil {
-				if _, ok := err.(net.Error); ok {
-					return nil
-				} else if err != ErrCloseSent {
-					return err
-				}
-			}
+			_ = c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
 			return nil
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -1158,10 +1158,7 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
-			if err != nil {
-				log.Printf("websocket: discarding close handler error: %v", err)
-			}
+			_ = c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
 			return nil
 		}
 	}

--- a/conn.go
+++ b/conn.go
@@ -1158,7 +1158,10 @@ func (c *Conn) SetCloseHandler(h func(code int, text string) error) {
 	if h == nil {
 		h = func(code int, text string) error {
 			message := FormatCloseMessage(code, "")
-			_ = c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
+			err := c.WriteControl(CloseMessage, message, time.Now().Add(writeWait))
+			if err != nil {
+				log.Printf("websocket: discarding close handler error: %v", err)
+			}
 			return nil
 		}
 	}


### PR DESCRIPTION
The 666c197 added an error handling in `SetCloseHandler()` and peer stops getting `CloseError` when network issue like `write: broken pipe` happens because the close handle returns the error.

Hence this patch changes to skip network error handling.
