### PR TITLE
fix: replace ioutil.readfile with os.readfile

### DIFF
--- a/examples/filewatch/main.go
+++ b/examples/filewatch/main.go
@@ -7,7 +7,6 @@ package main
 import (
 	"flag"
 	"html/template"
-	"io/ioutil"
 	"log"
 	"net/http"
 	"os"
@@ -50,7 +49,8 @@ func readFileIfModified(lastMod time.Time) ([]byte, time.Time, error) {
 	if !fi.ModTime().After(lastMod) {
 		return nil, lastMod, nil
 	}
-	p, err := ioutil.ReadFile(filepath.Clean(filename))
+
+	p, err := os.ReadFile(filepath.Clean(filename))
 	if err != nil {
 		return nil, fi.ModTime(), err
 	}


### PR DESCRIPTION
### summay

`ioutil.ReadFile` is Deprecated, As of Go 1.16, this function simply calls [os.ReadFile].