### PR TITLE
fix: add comment for the readBufferSize and writeBufferSize

### DIFF
--- a/server.go
+++ b/server.go
@@ -34,6 +34,7 @@ type Upgrader struct {
 	// size is zero, then buffers allocated by the HTTP server are used. The
 	// I/O buffer sizes do not limit the size of the messages that can be sent
 	// or received.
+	// The default value is 4096 bytes, 4kb.
 	ReadBufferSize, WriteBufferSize int
 
 	// WriteBufferPool is a pool of buffers for write operations. If the value


### PR DESCRIPTION
### summary

😅  Every time I use `gorilla/websocket`, I need to look at the source code and find the default size for readBufferSize and writeBufferSize.

I think the default value should be written in the comment.