### PR TITLE
Upgrader.Upgrade: use http.ResposnseController

### DIFF
--- a/server.go
+++ b/server.go
@@ -174,13 +174,11 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 		}
 	}
 
-	h, ok := w.(http.Hijacker)
-	if !ok {
+	netConn, brw, err := http.NewResponseController(w).Hijack()
+	switch {
+	case errors.Is(err, errors.ErrUnsupported):
 		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
-	}
-	var brw *bufio.ReadWriter
-	netConn, brw, err := h.Hijack()
-	if err != nil {
+	case err != nil:
 		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
 	}
 

--- a/server.go
+++ b/server.go
@@ -175,10 +175,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	}
 
 	netConn, brw, err := http.NewResponseController(w).Hijack()
-	switch {
-	case errors.Is(err, errors.ErrUnsupported):
-		return u.returnError(w, r, http.StatusInternalServerError, "websocket: response does not implement http.Hijacker")
-	case err != nil:
+	if err != nil {
 		return u.returnError(w, r, http.StatusInternalServerError, err.Error())
 	}
 

--- a/server_test.go
+++ b/server_test.go
@@ -7,8 +7,10 @@ package websocket
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"net"
 	"net/http"
+	"net/http/httptest"
 	"reflect"
 	"strings"
 	"testing"
@@ -150,5 +152,25 @@ func TestBufioReuse(t *testing.T) {
 		if reuse := &c.writeBuf[0] == &writeBuf[0]; reuse != tt.reuse {
 			t.Errorf("%d: write buffer reuse=%v, want %v", i, reuse, tt.reuse)
 		}
+	}
+}
+
+func TestHijack_NotSupported(t *testing.T) {
+	t.Parallel()
+
+	req := httptest.NewRequest(http.MethodGet, "http://example.com", nil)
+	req.Header.Set("Upgrade", "websocket")
+	req.Header.Set("Connection", "upgrade")
+	req.Header.Set("Sec-Websocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+	req.Header.Set("Sec-Websocket-Version", "13")
+
+	recorder := httptest.NewRecorder()
+
+	upgrader := Upgrader{}
+	_, err := upgrader.Upgrade(recorder, req, nil)
+
+	if want := (HandshakeError{}); !errors.As(err, &want) || recorder.Code != http.StatusInternalServerError {
+		t.Errorf("want %T and status_code=%d", want, http.StatusInternalServerError)
+		t.Fatalf("got err=%T and status_code=%d", err, recorder.Code)
 	}
 }


### PR DESCRIPTION
Since go1.20 [http.ResponseController](https://pkg.go.dev/net/http#ResponseController) is a preferable tool for connection hijacking. It allows to use custom response writer interceptors with `Unwrap()  http.ResponseWriter` method.