### PR TITLE
perf: reduce timer in write_control

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -454,13 +454,18 @@ func (c *Conn) WriteControl(messageType int, data []byte, deadline time.Time) er
 		}
 	}
 
-	timer := time.NewTimer(d)
 	select {
 	case <-c.mu:
-		timer.Stop()
-	case <-timer.C:
-		return errWriteTimeout
+	default:
+		timer := time.NewTimer(d)
+		select {
+		case <-c.mu:
+			timer.Stop()
+		case <-timer.C:
+			return errWriteTimeout
+		}
 	}
+
 	defer func() { c.mu <- struct{}{} }()
 
 	c.writeErrMu.Lock()


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

In most cases, we do not write concurrently to the same client, and the `gorilla` library limits the concurrency, when `gorilla` detect write data concurrently, throw panic ?  In the  addition, creating and stopping a timer is not a simple action. 😁

So, we can get the lock first and if we can't get it, we can create a timer. 😁

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
