### PR TITLE
feat: format message type

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1263,3 +1263,15 @@ func FormatCloseMessage(closeCode int, text string) []byte {
 	copy(buf[2:], text)
 	return buf
 }
+
+var messageTypes = map[int]string{
+	TextMessage:   "TextMessage",
+	BinaryMessage: "BinaryMessage",
+	CloseMessage:  "CloseMessage",
+	PingMessage:   "PingMessage",
+	PongMessage:   "PongMessage",
+}
+
+func FormatMessageType(mt int) string {
+	return messageTypes[mt]
+}

--- a/conn_test.go
+++ b/conn_test.go
@@ -797,3 +797,20 @@ func TestFailedConnectionReadPanic(t *testing.T) {
 	}
 	t.Fatal("should not get here")
 }
+
+func TestFormatMessageType(t *testing.T) {
+	str := FormatMessageType(TextMessage)
+	if str != messageTypes[TextMessage] {
+		t.Error("failed to format message type")
+	}
+
+	str = FormatMessageType(CloseMessage)
+	if str != messageTypes[CloseMessage] {
+		t.Error("failed to format message type")
+	}
+
+	str = FormatMessageType(123)
+	if str != messageTypes[123] {
+		t.Error("failed to format message type")
+	}
+}

--- a/examples/echo/client.go
+++ b/examples/echo/client.go
@@ -41,12 +41,12 @@ func main() {
 	go func() {
 		defer close(done)
 		for {
-			_, message, err := c.ReadMessage()
+			mt, message, err := c.ReadMessage()
 			if err != nil {
 				log.Println("read:", err)
 				return
 			}
-			log.Printf("recv: %s", message)
+			log.Printf("recv: %s, type: %s", message, websocket.FormatMessageType(mt))
 		}
 	}()
 

--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -33,7 +33,8 @@ func echo(w http.ResponseWriter, r *http.Request) {
 			log.Println("read:", err)
 			break
 		}
-		log.Printf("recv: %s", message)
+
+		log.Printf("recv: %s, type: %s", message, websocket.FormatMessageType(mt))
 		err = c.WriteMessage(mt, message)
 		if err != nil {
 			log.Println("write:", err)


### PR DESCRIPTION
### summary

The `messageType` and `message` can be retrieved using the readMessage method, i want to convert mt int to string by  `FormatMessageType` ? 😁 

```go
var upgrader = websocket.Upgrader{} // use default options

func echo(w http.ResponseWriter, r *http.Request) {
	c, err := upgrader.Upgrade(w, r, nil)
	if err != nil {
		log.Print("upgrade:", err)
		return
	}
	defer c.Close()
	for {
		mt, message, err := c.ReadMessage()
		if err != nil {
			log.Println("read:", err)
			break
		}

		log.Printf("recv: %s, type: %s", message, websocket.FormatMessageType(mt))  // 😁

		err = c.WriteMessage(mt, message)
		if err != nil {
			log.Println("write:", err)
			break
		}
	}
}
```