### PR TITLE
Remove hideTempErr to allow downstream users to check for errors like net.ErrClosed

### DIFF
--- a/conn_test.go
+++ b/conn_test.go
@@ -823,7 +823,6 @@ func (r fakeNetClosedReader) Read([]byte) (int, error) {
 }
 
 func TestConnectionClosed(t *testing.T) {
-	t.Parallel()
 	var b1, b2 bytes.Buffer
 
 	client := newTestConn(fakeNetClosedReader{}, &b1, false)

--- a/conn_test.go
+++ b/conn_test.go
@@ -814,3 +814,26 @@ func TestFormatMessageType(t *testing.T) {
 		t.Error("failed to format message type")
 	}
 }
+
+type fakeNetClosedReader struct {
+}
+
+func (r fakeNetClosedReader) Read([]byte) (int, error) {
+	return 0, net.ErrClosed
+}
+
+func TestConnectionClosed(t *testing.T) {
+	t.Parallel()
+	var b1, b2 bytes.Buffer
+
+	client := newTestConn(fakeNetClosedReader{}, &b1, false)
+	server := newTestConn(fakeNetClosedReader{}, &b2, true)
+
+	if _, _, err := server.NextReader(); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("server expects a net.ErrClosed error, %v returned", err)
+	}
+
+	if _, _, err := client.NextReader(); !errors.Is(err, net.ErrClosed) {
+		t.Fatalf("client expects a net.ErrClosed error, %v returned", err)
+	}
+}


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
Since this change https://github.com/gorilla/websocket/pull/840/files#diff-4f427d2b022907c552328e63f137561f6de92396d7a6e8f6c2ea1bcf0db52654L190-R197 we can no longer determinate if the errors coming from ReadMessage() are net.ErrClosed for example
Hardcoding the error message is not great option because it may vary from OS to OS and system locale

## Related Tickets & Documents
- Related Issue # https://github.com/gorilla/websocket/issues/877
- Closes # https://github.com/gorilla/websocket/issues/877

## Added/updated tests?

- [X] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [X] `make verify` is passing
- [X] `make test` is passing
