### PR TITLE
Remove `done` channel in client-server echo example

### DIFF
--- a/examples/echo/client.go
+++ b/examples/echo/client.go
@@ -36,10 +36,7 @@ func main() {
 	}
 	defer c.Close()
 
-	done := make(chan struct{})
-
 	go func() {
-		defer close(done)
 		for {
 			_, message, err := c.ReadMessage()
 			if err != nil {
@@ -55,8 +52,6 @@ func main() {
 
 	for {
 		select {
-		case <-done:
-			return
 		case t := <-ticker.C:
 			err := c.WriteMessage(websocket.TextMessage, []byte(t.String()))
 			if err != nil {
@@ -73,10 +68,7 @@ func main() {
 				log.Println("write close:", err)
 				return
 			}
-			select {
-			case <-done:
-			case <-time.After(time.Second):
-			}
+			<-time.After(time.Second)
 			return
 		}
 	}


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [x] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

I don't believe anything is actually sent to the `done` channel, in this example there are only statements reading from it. Furthermore, the deferred `close(done)` statement will never execute because deferred statements in other goroutines are not run when main terminates. So no messages will ever be sent to this channel and it will never be closed, so it is safe to remove all the references to `done`.

I took a look at https://github.com/gorilla/websocket/commit/844dd6d40e1a9215ef4c8a204bfc839fcf5dd5dd , where `done` was introduced, and the situation was similar then, so I believe this is an oversight in that commit.

## Related Tickets & Documents

None

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: I only slightly modified some code in an example application, and the functionality remains unaffected so there is nothing more to test
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [ ] `make test` is passing

I didn't run these ^ .
