### PR TITLE
Return errors instead of printing to logs

### DIFF
--- a/client_server_test.go
+++ b/client_server_test.go
@@ -430,10 +430,10 @@ func TestDialBadOrigin(t *testing.T) {
 		ws.Close()
 		t.Fatalf("Dial: nil")
 	}
-	if resp == nil {
+	if resp == nil { // nolint:staticcheck
 		t.Fatalf("resp=nil, err=%v", err)
 	}
-	if resp.StatusCode != http.StatusForbidden {
+	if resp.StatusCode != http.StatusForbidden { // nolint:staticcheck
 		t.Fatalf("status=%d, want %d", resp.StatusCode, http.StatusForbidden)
 	}
 }
@@ -551,11 +551,11 @@ func TestRespOnBadHandshake(t *testing.T) {
 		t.Fatalf("Dial: nil")
 	}
 
-	if resp == nil {
+	if resp == nil { // nolint:staticcheck
 		t.Fatalf("resp=nil, err=%v", err)
 	}
 
-	if resp.StatusCode != expectedStatus {
+	if resp.StatusCode != expectedStatus { // nolint:staticcheck
 		t.Errorf("resp.StatusCode=%d, want %d", resp.StatusCode, expectedStatus)
 	}
 

--- a/client_server_test.go
+++ b/client_server_test.go
@@ -92,6 +92,7 @@ func (t cstHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	ws, err := cstUpgrader.Upgrade(w, r, http.Header{"Set-Cookie": {"sessionID=1234"}})
 	if err != nil {
+		t.Logf("Upgrade: %v", err)
 		return
 	}
 	defer ws.Close()
@@ -103,16 +104,20 @@ func (t cstHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 	op, rd, err := ws.NextReader()
 	if err != nil {
+		t.Logf("NextReader: %v", err)
 		return
 	}
 	wr, err := ws.NextWriter(op)
 	if err != nil {
+		t.Logf("NextWriter: %v", err)
 		return
 	}
 	if _, err = io.Copy(wr, rd); err != nil {
+		t.Logf("Copy: %v", err)
 		return
 	}
 	if err := wr.Close(); err != nil {
+		t.Logf("Close: %v", err)
 		return
 	}
 }
@@ -430,7 +435,7 @@ func TestDialBadOrigin(t *testing.T) {
 		ws.Close()
 		t.Fatalf("Dial: nil")
 	}
-	if resp == nil { // nolint:staticcheck
+	if resp == nil {
 		t.Fatalf("resp=nil, err=%v", err)
 	}
 	if resp.StatusCode != http.StatusForbidden { // nolint:staticcheck
@@ -539,9 +544,7 @@ func TestRespOnBadHandshake(t *testing.T) {
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(expectedStatus)
-		if _, err := io.WriteString(w, expectedBody); err != nil {
-			t.Fatalf("WriteString: %v", err)
-		}
+		io.WriteString(w, expectedBody) // nolint:errcheck
 	}))
 	defer s.Close()
 
@@ -574,6 +577,7 @@ type testLogWriter struct {
 }
 
 func (w testLogWriter) Write(p []byte) (int, error) {
+	w.t.Logf("%s", p)
 	return len(p), nil
 }
 
@@ -793,10 +797,7 @@ func TestSocksProxyDial(t *testing.T) {
 		}
 		defer c1.Close()
 
-		if err := c1.SetDeadline(time.Now().Add(30 * time.Second)); err != nil {
-			t.Errorf("set deadline failed: %v", err)
-			return
-		}
+		c1.SetDeadline(time.Now().Add(30 * time.Second)) // nolint:errcheck
 
 		buf := make([]byte, 32)
 		if _, err := io.ReadFull(c1, buf[:3]); err != nil {
@@ -835,15 +836,10 @@ func TestSocksProxyDial(t *testing.T) {
 		defer c2.Close()
 		done := make(chan struct{})
 		go func() {
-			if _, err := io.Copy(c1, c2); err != nil {
-				t.Errorf("copy failed: %v", err)
-			}
+			io.Copy(c1, c2) // nolint:errcheck
 			close(done)
 		}()
-		if _, err := io.Copy(c2, c1); err != nil {
-			t.Errorf("copy failed: %v", err)
-			return
-		}
+		io.Copy(c2, c1) // nolint:errcheck
 		<-done
 	}()
 

--- a/compression.go
+++ b/compression.go
@@ -33,9 +33,7 @@ func decompressNoContextTakeover(r io.Reader) io.ReadCloser {
 		"\x01\x00\x00\xff\xff"
 
 	fr, _ := flateReaderPool.Get().(io.ReadCloser)
-	if err := fr.(flate.Resetter).Reset(io.MultiReader(r, strings.NewReader(tail)), nil); err != nil {
-		panic(err)
-	}
+	fr.(flate.Resetter).Reset(io.MultiReader(r, strings.NewReader(tail)), nil) //#nosec G104 (CWE-703): Errors unhandled
 	return &flateReadWrapper{fr}
 }
 
@@ -134,7 +132,7 @@ func (r *flateReadWrapper) Read(p []byte) (int, error) {
 		// Preemptively place the reader back in the pool. This helps with
 		// scenarios where the application does not call NextReader() soon after
 		// this final read.
-		_ = r.Close()
+		r.Close() //#nosec G104 (CWE-703): Errors unhandled
 	}
 	return n, err
 }

--- a/compression_test.go
+++ b/compression_test.go
@@ -23,9 +23,7 @@ func TestTruncWriter(t *testing.T) {
 			if m > n {
 				m = n
 			}
-			if _, err := w.Write(p[:m]); err != nil {
-				t.Fatal(err)
-			}
+			w.Write(p[:m]) // nolint:errcheck
 			p = p[m:]
 		}
 		if b.String() != data[:len(data)-len(w.p)] {
@@ -49,9 +47,7 @@ func BenchmarkWriteNoCompression(b *testing.B) {
 	messages := textMessages(100)
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := c.WriteMessage(TextMessage, messages[i%len(messages)]); err != nil {
-			b.Fatal(err)
-		}
+		c.WriteMessage(TextMessage, messages[i%len(messages)]) // nolint:errcheck
 	}
 	b.ReportAllocs()
 }
@@ -64,9 +60,7 @@ func BenchmarkWriteWithCompression(b *testing.B) {
 	c.newCompressionWriter = compressNoContextTakeover
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		if err := c.WriteMessage(TextMessage, messages[i%len(messages)]); err != nil {
-			b.Fatal(err)
-		}
+		c.WriteMessage(TextMessage, messages[i%len(messages)]) // nolint:errcheck
 	}
 	b.ReportAllocs()
 }

--- a/conn.go
+++ b/conn.go
@@ -934,9 +934,7 @@ func (c *Conn) advanceFrame() (int, error) {
 		}
 
 		if c.readLimit > 0 && c.readLength > c.readLimit {
-			if err := c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(writeWait)); err != nil {
-				return noFrame, err
-			}
+			c.WriteControl(CloseMessage, FormatCloseMessage(CloseMessageTooBig, ""), time.Now().Add(writeWait)) //#nosec G104 (CWE-703): Errors unhandled
 			return noFrame, ErrReadLimit
 		}
 
@@ -997,9 +995,7 @@ func (c *Conn) handleProtocolError(message string) error {
 	if len(data) > maxControlFramePayloadSize {
 		data = data[:maxControlFramePayloadSize]
 	}
-	if err := c.WriteControl(CloseMessage, data, time.Now().Add(writeWait)); err != nil {
-		return err
-	}
+	c.WriteControl(CloseMessage, data, time.Now().Add(writeWait)) //#nosec G104 (CWE-703): Errors unhandled
 	return errors.New("websocket: " + message)
 }
 


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
With #840 debug messages were printed to stderr, as this wasn't very application friendly. With this, the noise in the logs will be reduced, without impacting error handling.

## Related Tickets & Documents

- Closes #880 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: current tests does not cover the scenario of stderr logs, so no impact on tests with the changes.
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
