### PR TITLE
examples/echo changed variables for clarity and removed nonexistent method

### DIFF
--- a/examples/echo/client.go
+++ b/examples/echo/client.go
@@ -41,12 +41,16 @@ func main() {
 	go func() {
 		defer close(done)
 		for {
-			mt, message, err := c.ReadMessage()
+			messageType, message, err := c.ReadMessage()
 			if err != nil {
 				log.Println("read:", err)
 				return
 			}
-			log.Printf("recv: %s, type: %s", message, websocket.FormatMessageType(mt))
+			if messageType == websocket.TextMessage {
+				log.Printf("received text message: %s", message)
+			} else if messageType == websocket.BinaryMessage {
+				log.Printf("received binary message: %s", message)
+			}
 		}
 	}()
 
@@ -68,7 +72,10 @@ func main() {
 
 			// Cleanly close the connection by sending a close message and then
 			// waiting (with timeout) for the server to close the connection.
-			err := c.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
+			err := c.WriteMessage(
+				websocket.CloseMessage,
+				websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""),
+			)
 			if err != nil {
 				log.Println("write close:", err)
 				return

--- a/examples/echo/server.go
+++ b/examples/echo/server.go
@@ -28,14 +28,18 @@ func echo(w http.ResponseWriter, r *http.Request) {
 	}
 	defer c.Close()
 	for {
-		mt, message, err := c.ReadMessage()
+		messageType, message, err := c.ReadMessage()
 		if err != nil {
 			log.Println("read:", err)
 			break
 		}
 
-		log.Printf("recv: %s, type: %s", message, websocket.FormatMessageType(mt))
-		err = c.WriteMessage(mt, message)
+		if messageType == websocket.TextMessage {
+			log.Printf("received text message: %s", message)
+		} else if messageType == websocket.BinaryMessage {
+			log.Printf("received binary message: %s", message)
+		}
+		err = c.WriteMessage(messageType, message)
 		if err != nil {
 			log.Println("write:", err)
 			break
@@ -60,7 +64,7 @@ var homeTemplate = template.Must(template.New("").Parse(`
 <html>
 <head>
 <meta charset="utf-8">
-<script>  
+<script>
 window.addEventListener("load", function(evt) {
 
     var output = document.getElementById("output");
@@ -118,8 +122,8 @@ window.addEventListener("load", function(evt) {
 <body>
 <table>
 <tr><td valign="top" width="50%">
-<p>Click "Open" to create a connection to the server, 
-"Send" to send a message to the server and "Close" to close the connection. 
+<p>Click "Open" to create a connection to the server,
+"Send" to send a message to the server and "Close" to close the connection.
 You can change the message and send multiple times.
 <p>
 <form>


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [X] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
In the example/echo folder, an error has been introduced where a nonexistent function was used. I removed the error and renamed the variables for better clarity.

The variable was messageType that comes from conn.ReadMessage(). messageType is an int with value websocket.BinaryMessage or websocket.TextMessage. Before it was marked as _, but I believe the example would be improved if we used it in a simple way to show that it can be used as an indicator for the type of message.

## Related Tickets & Documents
I couldn't find related issues.

## Added/updated tests?

- [ ] Yes
- [X] No, and this is why: I just modified the example for the new users.
- [ ] I need help with writing tests

## Run verifications and test

- [X] `make verify` is passing
- [X] `make test` is passing

I ran them anyway, even though I didn't change any production code
