### PR TITLE
feat: add method to acknowledge expected/temporary read errors

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1007,8 +1007,9 @@ func (c *Conn) handleProtocolError(message string) error {
 //
 // Applications must break out of the application's read loop when this method
 // returns a non-nil error value. Errors returned from this method are
-// permanent. Once this method returns a non-nil error, all subsequent calls to
-// this method return the same error.
+// permanent, unless explicitly cleared using ClearReadError. Once this method
+// returns a non-nil error, all subsequent calls to this method return the
+// same error.
 func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 	// Close previous reader, only relevant for decompression.
 	if c.reader != nil {
@@ -1045,6 +1046,15 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 	}
 
 	return noFrame, nil, c.readErr
+}
+
+// ClearReadError clears the read error state of the connection. This is
+// primarily useful for handling expected errors such as read timeouts with
+// non-blocking I/O. Applications must be careful to ensure errors are
+// temporary before clearing them as not doing so will lead to busy loops.
+func (c *Conn) ClearReadError() {
+	c.readErr = nil
+	c.readErrCount--
 }
 
 type messageReader struct{ c *Conn }


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [x] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

Add a method for explicitly acknowledging read errors are temporary. This is useful when read timeouts are expected, such as in a non blocking loop with context cancellation etc.

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Closes #476 

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: negligible code changes
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing
