### PR TITLE
Expose tls connection state in http response

### DIFF
--- a/client_server_test.go
+++ b/client_server_test.go
@@ -330,6 +330,25 @@ func TestDialTLS(t *testing.T) {
 	sendRecv(t, ws)
 }
 
+func TestDialTLSConnState(t *testing.T) {
+	s := newTLSServer(t)
+	defer s.Close()
+
+	d := cstDialer
+	d.TLSClientConfig = &tls.Config{RootCAs: rootCAs(t, s.Server)}
+	ws, resp, err := d.Dial(s.URL, nil)
+	if err != nil {
+		t.Fatalf("Dial: %v", err)
+	}
+	if resp.TLS == nil {
+		t.Errorf("http response tls is nil")
+	} else if len(resp.TLS.PeerCertificates) == 0 {
+		t.Errorf("http response PeerCertificates count is 0")
+	}
+	defer ws.Close()
+	sendRecv(t, ws)
+}
+
 func TestDialTimeout(t *testing.T) {
 	s := newServer(t)
 	defer s.Close()


### PR DESCRIPTION
## What type of PR is this?

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

Expose TLS field in http.Response struct if tls handshake done in DialContext
https://pkg.go.dev/net/http@go1.20#Response

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [ ] `make test` is passing
