### PR TITLE
Fix autobahn example duplicate validator wrapping

### DIFF
--- a/examples/autobahn/server.go
+++ b/examples/autobahn/server.go
@@ -42,9 +42,6 @@ func echoCopy(w http.ResponseWriter, r *http.Request, writerOnly bool) {
 			}
 			return
 		}
-		if mt == websocket.TextMessage {
-			r = &validator{r: r}
-		}
 		w, err := conn.NextWriter(mt)
 		if err != nil {
 			log.Println("NextWriter:", err)


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [x] Refactor
- [ ] Feature
- [x] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

The reader is double wrapped by the validator for no reason that I can see.