### PR TITLE
Concurrent safe writes

### DIFF
--- a/doc.go
+++ b/doc.go
@@ -4,40 +4,40 @@
 
 // Package websocket implements the WebSocket protocol defined in RFC 6455.
 //
-// Overview
+// # Overview
 //
 // The Conn type represents a WebSocket connection. A server application calls
 // the Upgrader.Upgrade method from an HTTP request handler to get a *Conn:
 //
-//  var upgrader = websocket.Upgrader{
-//      ReadBufferSize:  1024,
-//      WriteBufferSize: 1024,
-//  }
+//	var upgrader = websocket.Upgrader{
+//	    ReadBufferSize:  1024,
+//	    WriteBufferSize: 1024,
+//	}
 //
-//  func handler(w http.ResponseWriter, r *http.Request) {
-//      conn, err := upgrader.Upgrade(w, r, nil)
-//      if err != nil {
-//          log.Println(err)
-//          return
-//      }
-//      ... Use conn to send and receive messages.
-//  }
+//	func handler(w http.ResponseWriter, r *http.Request) {
+//	    conn, err := upgrader.Upgrade(w, r, nil)
+//	    if err != nil {
+//	        log.Println(err)
+//	        return
+//	    }
+//	    ... Use conn to send and receive messages.
+//	}
 //
 // Call the connection's WriteMessage and ReadMessage methods to send and
 // receive messages as a slice of bytes. This snippet of code shows how to echo
 // messages using these methods:
 //
-//  for {
-//      messageType, p, err := conn.ReadMessage()
-//      if err != nil {
-//          log.Println(err)
-//          return
-//      }
-//      if err := conn.WriteMessage(messageType, p); err != nil {
-//          log.Println(err)
-//          return
-//      }
-//  }
+//	for {
+//	    messageType, p, err := conn.ReadMessage()
+//	    if err != nil {
+//	        log.Println(err)
+//	        return
+//	    }
+//	    if err := conn.WriteMessage(messageType, p); err != nil {
+//	        log.Println(err)
+//	        return
+//	    }
+//	}
 //
 // In above snippet of code, p is a []byte and messageType is an int with value
 // websocket.BinaryMessage or websocket.TextMessage.
@@ -49,24 +49,24 @@
 // method to get an io.Reader and read until io.EOF is returned. This snippet
 // shows how to echo messages using the NextWriter and NextReader methods:
 //
-//  for {
-//      messageType, r, err := conn.NextReader()
-//      if err != nil {
-//          return
-//      }
-//      w, err := conn.NextWriter(messageType)
-//      if err != nil {
-//          return err
-//      }
-//      if _, err := io.Copy(w, r); err != nil {
-//          return err
-//      }
-//      if err := w.Close(); err != nil {
-//          return err
-//      }
-//  }
+//	for {
+//	    messageType, r, err := conn.NextReader()
+//	    if err != nil {
+//	        return
+//	    }
+//	    w, err := conn.NextWriter(messageType)
+//	    if err != nil {
+//	        return err
+//	    }
+//	    if _, err := io.Copy(w, r); err != nil {
+//	        return err
+//	    }
+//	    if err := w.Close(); err != nil {
+//	        return err
+//	    }
+//	}
 //
-// Data Messages
+// # Data Messages
 //
 // The WebSocket protocol distinguishes between text and binary data messages.
 // Text messages are interpreted as UTF-8 encoded text. The interpretation of
@@ -80,7 +80,7 @@
 // It is the application's responsibility to ensure that text messages are
 // valid UTF-8 encoded text.
 //
-// Control Messages
+// # Control Messages
 //
 // The WebSocket protocol defines three types of control messages: close, ping
 // and pong. Call the connection WriteControl, WriteMessage or NextWriter
@@ -110,16 +110,16 @@
 // in messages from the peer, then the application should start a goroutine to
 // read and discard messages from the peer. A simple example is:
 //
-//  func readLoop(c *websocket.Conn) {
-//      for {
-//          if _, _, err := c.NextReader(); err != nil {
-//              c.Close()
-//              break
-//          }
-//      }
-//  }
+//	func readLoop(c *websocket.Conn) {
+//	    for {
+//	        if _, _, err := c.NextReader(); err != nil {
+//	            c.Close()
+//	            break
+//	        }
+//	    }
+//	}
 //
-// Concurrency
+// # Concurrency
 //
 // Connections support one concurrent reader and one concurrent writer.
 //
@@ -133,7 +133,7 @@
 // The Close and WriteControl methods can be called concurrently with all other
 // methods.
 //
-// Origin Considerations
+// # Origin Considerations
 //
 // Web browsers allow Javascript applications to open a WebSocket connection to
 // any host. It's up to the server to enforce an origin policy using the Origin
@@ -151,7 +151,7 @@
 // checking. The application is responsible for checking the Origin header
 // before calling the Upgrade function.
 //
-// Buffers
+// # Buffers
 //
 // Connections buffer network input and output to reduce the number
 // of system calls when reading or writing messages.
@@ -198,16 +198,16 @@
 // buffer size has a reduced impact on total memory use and has the benefit of
 // reducing system calls and frame overhead.
 //
-// Compression EXPERIMENTAL
+// # Compression EXPERIMENTAL
 //
 // Per message compression extensions (RFC 7692) are experimentally supported
 // by this package in a limited capacity. Setting the EnableCompression option
 // to true in Dialer or Upgrader will attempt to negotiate per message deflate
 // support.
 //
-//  var upgrader = websocket.Upgrader{
-//      EnableCompression: true,
-//  }
+//	var upgrader = websocket.Upgrader{
+//	    EnableCompression: true,
+//	}
 //
 // If compression was successfully negotiated with the connection's peer, any
 // message received in compressed form will be automatically decompressed.
@@ -216,7 +216,7 @@
 // Per message compression of messages written to a connection can be enabled
 // or disabled by calling the corresponding Conn method:
 //
-//  conn.EnableWriteCompression(false)
+//	conn.EnableWriteCompression(false)
 //
 // Currently this package does not support compression with "context takeover".
 // This means that messages must be compressed and decompressed in isolation,

--- a/prepared.go
+++ b/prepared.go
@@ -73,12 +73,10 @@ func (pm *PreparedMessage) frame(key prepareKey) (int, []byte, error) {
 		// Prepare a frame using a 'fake' connection.
 		// TODO: Refactor code in conn.go to allow more direct construction of
 		// the frame.
-		mu := make(chan struct{}, 1)
-		mu <- struct{}{}
 		var nc prepareConn
 		c := &Conn{
 			conn:                   &nc,
-			mu:                     mu,
+			writeMux:               &sync.Mutex{},
 			isServer:               key.isServer,
 			compressionLevel:       key.compressionLevel,
 			enableWriteCompression: true,

--- a/server.go
+++ b/server.go
@@ -370,4 +370,3 @@ func (b *brNetConn) Read(p []byte) (n int, err error) {
 func (b *brNetConn) NetConn() net.Conn {
 	return b.Conn
 }
-


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [x] Feature

## Description

Implements concurrency-safe write functions, using a mutex, as suggested in https://github.com/gorilla/websocket/issues/826 and https://github.com/gorilla/websocket/issues/828

## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issues: 
  - https://github.com/gorilla/websocket/issues/826
  - https://github.com/gorilla/websocket/issues/828

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [ ] `make verify` is passing
- [x] `make test` is passing
