### PR TITLE
Deflake proxy unit tests

### DIFF
--- a/client_proxy_server_test.go
+++ b/client_proxy_server_test.go
@@ -43,13 +43,13 @@ func TestHTTPProxyAndBackend(t *testing.T) {
 	websocketTLS := false
 	proxyTLS := false
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -80,13 +80,13 @@ func TestHTTPProxyWithNetDial(t *testing.T) {
 	websocketTLS := false
 	proxyTLS := false
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -125,13 +125,13 @@ func TestHTTPProxyWithNetDialContext(t *testing.T) {
 	websocketTLS := false
 	proxyTLS := false
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -171,13 +171,13 @@ func TestHTTPProxyWithHTTPSBackend(t *testing.T) {
 	websocketTLS := true
 	proxyTLS := false
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -219,13 +219,13 @@ func TestHTTPSProxyAndBackend(t *testing.T) {
 	websocketTLS := true
 	proxyTLS := true
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -257,13 +257,13 @@ func TestHTTPSProxyUsingNetDial(t *testing.T) {
 	websocketTLS := true
 	proxyTLS := true
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -303,13 +303,13 @@ func TestHTTPSProxyUsingNetDialContext(t *testing.T) {
 	websocketTLS := true
 	proxyTLS := true
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -349,13 +349,13 @@ func TestHTTPSProxyUsingNetDialTLSContext(t *testing.T) {
 	websocketTLS := true
 	proxyTLS := true
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -408,13 +408,13 @@ func TestHTTPSProxyHTTPBackend(t *testing.T) {
 	websocketTLS := false
 	proxyTLS := true
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -446,13 +446,13 @@ func TestHTTPSProxyUsingNetDialTLSContextWithHTTPBackend(t *testing.T) {
 	websocketTLS := false
 	proxyTLS := true
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
 	// Start the proxy server.
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -486,12 +486,12 @@ func TestTLSValidationErrors(t *testing.T) {
 	// Both websocket and proxy servers are started with TLS.
 	websocketTLS := true
 	proxyTLS := true
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
-	proxyServer, proxyServerURL, err := newProxyServer(proxyTLS)
+	proxyServer, proxyServerURL, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -534,7 +534,7 @@ func TestTLSValidationErrors(t *testing.T) {
 }
 
 func TestProxyFnErrorIsPropagated(t *testing.T) {
-	websocketServer, websocketURL, err := newWebsocketServer(false)
+	websocketServer, websocketURL, err := newWebsocketServer(t, false)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
@@ -560,12 +560,12 @@ func TestProxyFnNilMeansNoProxy(t *testing.T) {
 	// Both websocket and proxy servers are started.
 	websocketTLS := false
 	proxyTLS := false
-	websocketServer, websocketURL, err := newWebsocketServer(websocketTLS)
+	websocketServer, websocketURL, err := newWebsocketServer(t, websocketTLS)
 	defer websocketServer.Close()
 	if err != nil {
 		t.Fatalf("error starting websocket server: %v", err)
 	}
-	proxyServer, _, err := newProxyServer(proxyTLS)
+	proxyServer, _, err := newProxyServer(t, proxyTLS)
 	defer proxyServer.Close()
 	if err != nil {
 		t.Fatalf("error starting proxy server: %v", err)
@@ -623,51 +623,54 @@ func (ts *testServer) Close() {
 	}
 }
 
-// websocketEchoHandler upgrades the connection associated with the request, and
-// echoes binary messages read off the websocket connection back to the client.
-var websocketEchoHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-	upgrader := Upgrader{
-		CheckOrigin: func(r *http.Request) bool {
-			return true // Accepting all requests
-		},
-		Subprotocols: []string{
-			subprotocolV1,
-			subprotocolV2,
-		},
-	}
-	wsConn, err := upgrader.Upgrade(w, req, nil)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-	}
-	defer wsConn.Close()
-	for {
-		writer, err := wsConn.NextWriter(BinaryMessage)
+// newWebsocketEchoHandler returns a handler that upgrades the connection associated with the request,
+// and echoes binary messages read off the websocket connection back to the client.
+func newWebsocketEchoHandler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		upgrader := Upgrader{
+			CheckOrigin: func(r *http.Request) bool {
+				return true // Accepting all requests
+			},
+			Subprotocols: []string{
+				subprotocolV1,
+				subprotocolV2,
+			},
+		}
+		wsConn, err := upgrader.Upgrade(w, req, nil)
 		if err != nil {
-			break
+			t.Logf("websocketEchoHandler Upgrade: %v, %#v", err, req)
+			return
 		}
-		messageType, reader, err := wsConn.NextReader()
-		if err != nil {
-			break
+		defer wsConn.Close()
+		for {
+			writer, err := wsConn.NextWriter(BinaryMessage)
+			if err != nil {
+				break
+			}
+			messageType, reader, err := wsConn.NextReader()
+			if err != nil {
+				break
+			}
+			if messageType != BinaryMessage {
+				t.Log("websocket reader not binary message type")
+				break
+			}
+			_, err = io.Copy(writer, reader)
+			if err != nil {
+				t.Log("websocket server io copy error")
+				break
+			}
 		}
-		if messageType != BinaryMessage {
-			http.Error(w, "websocket reader not binary message type",
-				http.StatusInternalServerError)
-		}
-		_, err = io.Copy(writer, reader)
-		if err != nil {
-			http.Error(w, "websocket server io copy error",
-				http.StatusInternalServerError)
-		}
-	}
-})
+	})
+}
 
 // Returns a test backend websocket server as well as the URL pointing
 // to the server, or an error if one occurred. Sets up a TLS endpoint
 // on the server if the passed "tlsServer" is true.
 // func newWebsocketServer(tlsServer bool) (*httptest.Server, *url.URL, error) {
-func newWebsocketServer(tlsServer bool) (closer, *url.URL, error) {
+func newWebsocketServer(t *testing.T, tlsServer bool) (closer, *url.URL, error) {
 	// Start the websocket server, which echoes data back to sender.
-	websocketServer := httptest.NewUnstartedServer(websocketEchoHandler)
+	websocketServer := httptest.NewUnstartedServer(newWebsocketEchoHandler(t))
 	if tlsServer {
 		websocketKeyPair, err := tls.X509KeyPair(websocketServerCert, websocketServerKey)
 		if err != nil {
@@ -695,45 +698,59 @@ func newWebsocketServer(tlsServer bool) (closer, *url.URL, error) {
 // proxyHandler creates a full duplex streaming connection between the client
 // (hijacking the http request connection), and an "upstream" dialed connection
 // to the "Host". Creates two goroutines to copy between connections in each direction.
-var proxyHandler = http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
-	// Validate the CONNECT method.
-	if req.Method != http.MethodConnect {
-		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
-		return
-	}
-	// Dial upstream server.
-	upstream, err := (&net.Dialer{}).DialContext(req.Context(), "tcp", req.URL.Host)
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer upstream.Close()
-	// Return 200 OK to client.
-	w.WriteHeader(http.StatusOK)
-	// Hijack client connection.
-	client, _, err := w.(http.Hijacker).Hijack()
-	if err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
-	defer client.Close()
-	// Create duplex streaming between client and upstream connections.
-	done := make(chan struct{}, 2)
-	go func() {
-		_, _ = io.Copy(upstream, client)
-		done <- struct{}{}
-	}()
-	go func() {
-		_, _ = io.Copy(client, upstream)
-		done <- struct{}{}
-	}()
-	<-done
-})
+func newProxyHandler(t *testing.T) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+		// Validate the CONNECT method.
+		if req.Method != http.MethodConnect {
+			http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+			return
+		}
+		// Dial upstream server.
+		upstream, err := (&net.Dialer{}).DialContext(req.Context(), "tcp", req.URL.Host)
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer upstream.Close()
+		// Return 200 OK to client.
+		w.WriteHeader(http.StatusOK)
+		// Hijack client connection.
+		client, brw, err := w.(http.Hijacker).Hijack()
+		if err != nil {
+			http.Error(w, err.Error(), http.StatusInternalServerError)
+			return
+		}
+		defer client.Close()
+
+		// flush any buffered reads/writes
+		if err := brw.Flush(); err != nil {
+			t.Logf("Failed to flush pending writes to client, host=%s: %v\n", req.Host, err)
+			return
+		}
+		if _, err := io.Copy(upstream, io.LimitReader(brw, int64(brw.Reader.Buffered()))); err != nil {
+			t.Logf("Failed to flush buffered reads to server, host=%s: %v\n", req.Host, err)
+			return
+		}
+
+		// Create duplex streaming between client and upstream connections.
+		done := make(chan struct{}, 2)
+		go func() {
+			_, _ = io.Copy(upstream, client)
+			done <- struct{}{}
+		}()
+		go func() {
+			_, _ = io.Copy(client, upstream)
+			done <- struct{}{}
+		}()
+		<-done
+	})
+}
 
 // Returns a new test HTTP server, as well as the URL to that server, or
 // an error if one occurred. numProxyCalls keeps track of the number of
 // times the proxy handler was called with this server.
-func newProxyServer(tlsServer bool) (counter, *url.URL, error) {
+func newProxyServer(t *testing.T, tlsServer bool) (counter, *url.URL, error) {
+	proxyHandler := newProxyHandler(t)
 	// Start the proxy server, keeping track of how many times the handler is called.
 	ts := &testServer{}
 	proxyServer := httptest.NewUnstartedServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
@@ -752,6 +769,7 @@ func newProxyServer(tlsServer bool) (counter, *url.URL, error) {
 	} else {
 		proxyServer.Start()
 	}
+	ts.server = proxyServer
 	proxyURL, err := url.Parse(proxyServer.URL)
 	if err != nil {
 		return nil, nil, err


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Bug Fix

This PR is best viewed ignoring whitespace (a couple functions just got indented) - https://github.com/gorilla/websocket/pull/982/files?w=1

## Description

I noticed a flake on `main` unit tests at https://app.circleci.com/pipelines/github/gorilla/websocket/424/workflows/e37b2052-9796-4d0e-b3f6-9c6f72980e3f/jobs/1529?utm_campaign=vcs-integration-link&utm_medium=referral&utm_source=github-checks-link&utm_content=summary

Dug in and found a few tweaks needed in the unit tests from https://github.com/gorilla/websocket/pull/978

This PR:
1. Correctly closes the test proxy server
2. Correctly handles any buffered data when hijacking the connection in the test handler
3. Fixes a panic if the upgrade failed inside the test websocket handler (was happening due to not handling the buffered data)
4. Switches from calling http.Error after Upgrade (which doesn't work) to logging errors to the test logger

## Added/updated tests?

- [x] Yes, fixed unit test flakes

## Run verifications and test

```
go test -race ./...
ok  	github.com/gorilla/websocket	2.616s
?   	github.com/gorilla/websocket/examples/autobahn	[no test files]
?   	github.com/gorilla/websocket/examples/chat	[no test files]
?   	github.com/gorilla/websocket/examples/command	[no test files]
?   	github.com/gorilla/websocket/examples/filewatch	[no test files]
```


On `main`:
```
$ go test -race -c .
$ stress ./websocket.test 

/var/folders/37/ns7gt60104scfm9fvg02p1jh00kjgb/T/go-stress-20250320T105828-994893878
2025/03/20 10:58:28 http: superfluous response.WriteHeader call from github.com/gorilla/websocket.init.func2 (client_proxy_server_test.go:640)
2025/03/20 10:58:28 http: panic serving 127.0.0.1:55001: runtime error: invalid memory address or nil pointer dereference
goroutine 15 [running]:
net/http.(*conn).serve.func1()
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/net/http/server.go:1947 +0xe4
panic({0x104d71fa0?, 0x1050a4500?})
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/runtime/panic.go:787 +0x124
github.com/gorilla/websocket.(*Conn).Close(...)
	/Users/liggitt/go/src/github.com/gorilla/websocket/conn.go:344
panic({0x104d71fa0?, 0x1050a4500?})
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/runtime/panic.go:787 +0x124
github.com/gorilla/websocket.(*Conn).beginMessage(0x0, 0xc0000fecc0, 0x2)
	/Users/liggitt/go/src/github.com/gorilla/websocket/conn.go:488 +0x30
github.com/gorilla/websocket.(*Conn).NextWriter(0x0, 0x2)
	/Users/liggitt/go/src/github.com/gorilla/websocket/conn.go:529 +0x78
github.com/gorilla/websocket.init.func2({0x104ded610, 0xc0002860e0}, 0xc0000f4640)
	/Users/liggitt/go/src/github.com/gorilla/websocket/client_proxy_server_test.go:644 +0x1b4
net/http.HandlerFunc.ServeHTTP(0x104de5880, {0x104ded610, 0xc0002860e0}, 0xc0000f4640)
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/net/http/server.go:2294 +0x4c
net/http.serverHandler.ServeHTTP({0xc0000fea50?}, {0x104ded610, 0xc0002860e0}, 0xc0000f4640)
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/net/http/server.go:3301 +0x29c
net/http.(*conn).serve(0xc0000d4990, {0x104ded928, 0xc0000fe930})
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/net/http/server.go:2102 +0xeb8
created by net/http.(*Server).Serve in goroutine 37
	/Users/liggitt/.gimme/versions/go1.24.0.darwin.arm64/src/net/http/server.go:3454 +0x678
--- FAIL: TestHTTPProxyWithNetDialContext (0.00s)
    client_proxy_server_test.go:151: websocket dial error: unexpected EOF
2025/03/20 10:58:29 http: TLS handshake error from 127.0.0.1:
…
1m0s: 217 runs so far, 6 failures (2.76%), 10 active
```

With this PR:
```
$ go test -race -c .
$ stress ./websocket.test 
5s: 10 runs so far, 0 failures, 10 active
10s: 30 runs so far, 0 failures, 10 active
15s: 48 runs so far, 0 failures, 10 active
20s: 66 runs so far, 0 failures, 10 active
25s: 83 runs so far, 0 failures, 10 active
30s: 93 runs so far, 0 failures, 10 active
35s: 111 runs so far, 0 failures, 10 active
40s: 131 runs so far, 0 failures, 10 active
45s: 151 runs so far, 0 failures, 10 active
50s: 169 runs so far, 0 failures, 10 active
55s: 187 runs so far, 0 failures, 10 active
1m0s: 205 runs so far, 0 failures, 10 active
1m5s: 223 runs so far, 0 failures, 10 active
1m10s: 241 runs so far, 0 failures, 10 active
1m15s: 254 runs so far, 0 failures, 10 active
1m20s: 268 runs so far, 0 failures, 10 active
1m25s: 286 runs so far, 0 failures, 10 active
1m30s: 304 runs so far, 0 failures, 10 active
1m35s: 322 runs so far, 0 failures, 10 active
1m40s: 340 runs so far, 0 failures, 10 active
1m45s: 358 runs so far, 0 failures, 10 active
1m50s: 376 runs so far, 0 failures, 10 active
1m55s: 394 runs so far, 0 failures, 10 active
2m0s: 412 runs so far, 0 failures, 10 active
2m5s: 435 runs so far, 0 failures, 10 active
2m10s: 455 runs so far, 0 failures, 10 active
2m15s: 474 runs so far, 0 failures, 10 active
2m20s: 492 runs so far, 0 failures, 10 active
2m25s: 510 runs so far, 0 failures, 10 active
2m30s: 528 runs so far, 0 failures, 10 active
...
```


cc @seans3 @aojea