### PR TITLE
enh: add disableClientMask option for WebSocket payload masking and optimize mask calculation

### DIFF
--- a/mask.go
+++ b/mask.go
@@ -13,7 +13,7 @@ const wordSize = int(unsafe.Sizeof(uintptr(0)))
 
 func maskBytes(key [4]byte, pos int, b []byte) int {
 	// Mask one byte at a time for small buffers.
-	if len(b) < 2*wordSize {
+	if len(b) <= 2*wordSize {
 		for i := range b {
 			b[i] ^= key[pos&3]
 			pos++
@@ -21,6 +21,9 @@ func maskBytes(key [4]byte, pos int, b []byte) int {
 		return pos & 3
 	}
 
+	if key == [4]byte{} {
+		return (pos + len(b)) & 3
+	}
 	// Mask one byte at a time to word boundary.
 	if n := int(uintptr(unsafe.Pointer(&b[0]))) % wordSize; n != 0 {
 		n = wordSize - n
@@ -32,16 +35,27 @@ func maskBytes(key [4]byte, pos int, b []byte) int {
 	}
 
 	// Create aligned word size key.
+	var kw uintptr
 	var k [wordSize]byte
-	for i := range k {
-		k[i] = key[(pos+i)&3]
+	if wordSize == 8 {
+		k[0] = key[(pos+0)&3]
+		k[1] = key[(pos+1)&3]
+		k[2] = key[(pos+2)&3]
+		k[3] = key[(pos+3)&3]
+		kw = *(*uintptr)(unsafe.Pointer(&k))
+		kw = (kw << 32) | kw
+	} else {
+		for i := range k {
+			k[i] = key[(pos+i)&3]
+		}
+		kw = *(*uintptr)(unsafe.Pointer(&k))
 	}
-	kw := *(*uintptr)(unsafe.Pointer(&k))
 
 	// Mask one word at a time.
 	n := (len(b) / wordSize) * wordSize
+	p0 := unsafe.Pointer(&b[0])
 	for i := 0; i < n; i += wordSize {
-		*(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&b[0])) + uintptr(i))) ^= kw
+		*(*uintptr)(unsafe.Pointer(uintptr(p0) + uintptr(i))) ^= kw
 	}
 
 	// Mask one byte at a time for remaining bytes.

--- a/mask_test.go
+++ b/mask_test.go
@@ -7,8 +7,11 @@
 package websocket
 
 import (
+	"bytes"
 	"fmt"
+	"math/rand"
 	"testing"
+	"unsafe"
 )
 
 func maskBytesByByte(key [4]byte, pos int, b []byte) int {
@@ -28,6 +31,49 @@ func notzero(b []byte) int {
 	return -1
 }
 
+func maskBytesV1(key [4]byte, pos int, b []byte) int {
+	// Mask one byte at a time for small buffers.
+	if len(b) < 2*wordSize {
+		for i := range b {
+			b[i] ^= key[pos&3]
+			pos++
+		}
+		return pos & 3
+	}
+
+	// Mask one byte at a time to word boundary.
+	if n := int(uintptr(unsafe.Pointer(&b[0]))) % wordSize; n != 0 {
+		n = wordSize - n
+		for i := range b[:n] {
+			b[i] ^= key[pos&3]
+			pos++
+		}
+		b = b[n:]
+	}
+
+	// Create aligned word size key.
+	var k [wordSize]byte
+	for i := range k {
+		k[i] = key[(pos+i)&3]
+	}
+	kw := *(*uintptr)(unsafe.Pointer(&k))
+
+	// Mask one word at a time.
+	n := (len(b) / wordSize) * wordSize
+	for i := 0; i < n; i += wordSize {
+		*(*uintptr)(unsafe.Pointer(uintptr(unsafe.Pointer(&b[0])) + uintptr(i))) ^= kw
+	}
+
+	// Mask one byte at a time for remaining bytes.
+	b = b[n:]
+	for i := range b {
+		b[i] ^= key[pos&3]
+		pos++
+	}
+
+	return pos & 3
+}
+
 func TestMaskBytes(t *testing.T) {
 	key := [4]byte{1, 2, 3, 4}
 	for size := 1; size <= 1024; size++ {
@@ -44,8 +90,39 @@ func TestMaskBytes(t *testing.T) {
 	}
 }
 
+func TestMaskBytesWithRandomMessage(t *testing.T) {
+	keys := [][4]byte{
+		{1, 2, 3, 4},
+		{0, 0, 0, 0},
+	}
+	for _, key := range keys {
+		for size := 1; size <= 1024; size++ {
+			for align := 0; align < wordSize; align++ {
+				for pos := 0; pos < 4; pos++ {
+					byteMessage := make([]byte, size+align)[align:]
+					for i := 0; i < len(byteMessage); i++ {
+						byteMessage[i] = uint8(rand.Uint32())
+					}
+					byteMessageCopy := make([]byte, len(byteMessage))
+					copy(byteMessageCopy, byteMessage)
+					posBytes := maskBytes(key, pos, byteMessage)
+					posBytesByByte := maskBytesByByte(key, pos, byteMessageCopy)
+					if posBytes != posBytesByByte {
+						t.Errorf("keys:%v, size:%d, align:%d, pos:%d", key, size, align, pos)
+						return
+					}
+					if !bytes.Equal(byteMessage, byteMessageCopy) {
+						t.Errorf("keys:%v, size:%d, align:%d, pos:%d", key, size, align, pos)
+						return
+					}
+				}
+			}
+		}
+	}
+}
+
 func BenchmarkMaskBytes(b *testing.B) {
-	for _, size := range []int{2, 4, 8, 16, 32, 512, 1024} {
+	for _, size := range []int{2, 4, 8, 16, 32, 512, 1024, 1048576} {
 		b.Run(fmt.Sprintf("size-%d", size), func(b *testing.B) {
 			for _, align := range []int{wordSize / 2} {
 				b.Run(fmt.Sprintf("align-%d", align), func(b *testing.B) {
@@ -54,11 +131,13 @@ func BenchmarkMaskBytes(b *testing.B) {
 						fn   func(key [4]byte, pos int, b []byte) int
 					}{
 						{"byte", maskBytesByByte},
+						{"wordV1", maskBytesV1},
 						{"word", maskBytes},
 					} {
 						b.Run(fn.name, func(b *testing.B) {
 							key := newMaskKey()
 							data := make([]byte, size+align)[align:]
+							b.ResetTimer()
 							for i := 0; i < b.N; i++ {
 								fn.fn(key, 0, data)
 							}

--- a/prepared.go
+++ b/prepared.go
@@ -25,9 +25,10 @@ type PreparedMessage struct {
 
 // prepareKey defines a unique set of options to cache prepared frames in PreparedMessage.
 type prepareKey struct {
-	isServer         bool
-	compress         bool
-	compressionLevel int
+	isServer          bool
+	compress          bool
+	compressionLevel  int
+	disableClientMask bool
 }
 
 // preparedFrame contains data in wire representation.
@@ -83,6 +84,7 @@ func (pm *PreparedMessage) frame(key prepareKey) (int, []byte, error) {
 			compressionLevel:       key.compressionLevel,
 			enableWriteCompression: true,
 			writeBuf:               make([]byte, defaultWriteBufferSize+maxFrameHeaderSize),
+			disableClientMask:      key.disableClientMask,
 		}
 		if key.compress {
 			c.newCompressionWriter = compressNoContextTakeover


### PR DESCRIPTION
<!--
     For Work In Progress Pull Requests, please use the Draft PR feature,
     see https://github.blog/2019-02-14-introducing-draft-pull-requests/ for further details.

     For a timely review/response, please avoid force-pushing additional
     commits if your PR already received reviews or comments.

     Before submitting a Pull Request, please ensure that you have:
     - 📖 Read the Contributing guide: https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md
     - 📖 Read the Code of Conduct: https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md

     - Provide tests for your changes.
     - Use descriptive commit messages.
	 - Comment your code where appropriate.
	 - Squash your commits
     - Update any related documentation.

     - Add gorilla/pull-request-reviewers as a Reviewer
-->

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description
Optimized WebSocket masking by:
1. Implementing fast-path bypass when mask key equals [4]byte{0,0,0,0}
2. Adding configurable masking disablement for secure contexts (e.g., TLS)
```text
goos: linux
goarch: amd64
pkg: github.com/gorilla/websocket
cpu: Intel(R) Core(TM) i7-10700 CPU @ 2.90GHz
BenchmarkMaskBytes
BenchmarkMaskBytes/size-2
BenchmarkMaskBytes/size-2/align-4
BenchmarkMaskBytes/size-2/align-4/byte
BenchmarkMaskBytes/size-2/align-4/byte-16         	455632444	         2.629 ns/op	 760.76 MB/s
BenchmarkMaskBytes/size-2/align-4/wordV1
BenchmarkMaskBytes/size-2/align-4/wordV1-16       	421480846	         2.849 ns/op	 702.07 MB/s
BenchmarkMaskBytes/size-2/align-4/word
BenchmarkMaskBytes/size-2/align-4/word-16         	423765326	         2.828 ns/op	 707.18 MB/s
BenchmarkMaskBytes/size-4
BenchmarkMaskBytes/size-4/align-4
BenchmarkMaskBytes/size-4/align-4/byte
BenchmarkMaskBytes/size-4/align-4/byte-16         	290015848	         4.140 ns/op	 966.14 MB/s
BenchmarkMaskBytes/size-4/align-4/wordV1
BenchmarkMaskBytes/size-4/align-4/wordV1-16       	323833113	         3.735 ns/op	1071.01 MB/s
BenchmarkMaskBytes/size-4/align-4/word
BenchmarkMaskBytes/size-4/align-4/word-16         	323727016	         3.692 ns/op	1083.36 MB/s
BenchmarkMaskBytes/size-8
BenchmarkMaskBytes/size-8/align-4
BenchmarkMaskBytes/size-8/align-4/byte
BenchmarkMaskBytes/size-8/align-4/byte-16         	220623301	         5.432 ns/op	1472.64 MB/s
BenchmarkMaskBytes/size-8/align-4/wordV1
BenchmarkMaskBytes/size-8/align-4/wordV1-16       	212184852	         5.671 ns/op	1410.73 MB/s
BenchmarkMaskBytes/size-8/align-4/word
BenchmarkMaskBytes/size-8/align-4/word-16         	211640461	         5.642 ns/op	1417.93 MB/s
BenchmarkMaskBytes/size-16
BenchmarkMaskBytes/size-16/align-4
BenchmarkMaskBytes/size-16/align-4/byte
BenchmarkMaskBytes/size-16/align-4/byte-16        	128340018	         9.387 ns/op	1704.47 MB/s
BenchmarkMaskBytes/size-16/align-4/wordV1
BenchmarkMaskBytes/size-16/align-4/wordV1-16      	85413890	        14.01 ns/op	1142.38 MB/s
BenchmarkMaskBytes/size-16/align-4/word
BenchmarkMaskBytes/size-16/align-4/word-16        	125297701	         9.564 ns/op	1673.03 MB/s
BenchmarkMaskBytes/size-32
BenchmarkMaskBytes/size-32/align-4
BenchmarkMaskBytes/size-32/align-4/byte
BenchmarkMaskBytes/size-32/align-4/byte-16        	70067914	        17.31 ns/op	1848.34 MB/s
BenchmarkMaskBytes/size-32/align-4/wordV1
BenchmarkMaskBytes/size-32/align-4/wordV1-16      	81590757	        14.68 ns/op	2180.16 MB/s
BenchmarkMaskBytes/size-32/align-4/word
BenchmarkMaskBytes/size-32/align-4/word-16        	90093694	        13.32 ns/op	2402.45 MB/s
BenchmarkMaskBytes/size-512
BenchmarkMaskBytes/size-512/align-4
BenchmarkMaskBytes/size-512/align-4/byte
BenchmarkMaskBytes/size-512/align-4/byte-16       	 4654480	       256.3 ns/op	1997.71 MB/s
BenchmarkMaskBytes/size-512/align-4/wordV1
BenchmarkMaskBytes/size-512/align-4/wordV1-16     	30228372	        39.81 ns/op	12862.16 MB/s
BenchmarkMaskBytes/size-512/align-4/word
BenchmarkMaskBytes/size-512/align-4/word-16       	38939992	        30.81 ns/op	16616.76 MB/s
BenchmarkMaskBytes/size-1024
BenchmarkMaskBytes/size-1024/align-4
BenchmarkMaskBytes/size-1024/align-4/byte
BenchmarkMaskBytes/size-1024/align-4/byte-16      	 2361459	       506.7 ns/op	2020.90 MB/s
BenchmarkMaskBytes/size-1024/align-4/wordV1
BenchmarkMaskBytes/size-1024/align-4/wordV1-16    	18674653	        64.18 ns/op	15955.39 MB/s
BenchmarkMaskBytes/size-1024/align-4/word
BenchmarkMaskBytes/size-1024/align-4/word-16      	22626250	        52.46 ns/op	19518.92 MB/s
BenchmarkMaskBytes/size-1048576
BenchmarkMaskBytes/size-1048576/align-4
BenchmarkMaskBytes/size-1048576/align-4/byte
BenchmarkMaskBytes/size-1048576/align-4/byte-16   	    2314	    517830 ns/op	2024.94 MB/s
BenchmarkMaskBytes/size-1048576/align-4/wordV1
BenchmarkMaskBytes/size-1048576/align-4/wordV1-16 	   23004	     53214 ns/op	19704.72 MB/s
BenchmarkMaskBytes/size-1048576/align-4/word
BenchmarkMaskBytes/size-1048576/align-4/word-16   	   25855	     46638 ns/op	22483.08 MB/s
```
## Related Tickets & Documents

<!--
For pull requests that relate or close an issue, please include them
below.  We like to follow [Github's guidance on linking issues to pull requests](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue).

For example having the text: "closes #1234" would connect the current pull
request to issue 1234.  And when we merge the pull request, Github will
automatically close the issue.
-->

- Related Issue #
- Closes #

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
