### PR TITLE
Client's buffer for non-101 response body issue optimization proposition

### DIFF
--- a/client.go
+++ b/client.go
@@ -172,6 +172,7 @@ var nilDialer = *DefaultDialer
 // non-nil *http.Response so that callers can handle redirects, authentication,
 // etcetera. The response body may not contain the entire response and does not
 // need to be closed by the application.
+var maxErrorResponseSize = 4096
 func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
 	if d == nil {
 		d = &nilDialer
@@ -364,9 +365,14 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 		// Before closing the network connection on return from this
 		// function, slurp up some of the response to aid application
 		// debugging.
-		buf := make([]byte, 1024)
-		n, _ := io.ReadFull(resp.Body, buf)
-		resp.Body = io.NopCloser(bytes.NewReader(buf[:n]))
+
+		// Mon implémentation avec une maxErrorResponseSize
+		limReader := io.LimitReader(resp.Body, int64(maxErrorResponseSize))
+		buf, err := io.ReadAll(limReader)
+		if err != nil && err != io.EOF {
+			buf = []byte{}
+		}
+		resp.Body = io.NopCloser(bytes.NewReader(buf))
 		return nil, resp, ErrBadHandshake
 	}
 

--- a/client.go
+++ b/client.go
@@ -125,6 +125,11 @@ type Dialer struct {
 	// If Jar is nil, cookies are not sent in requests and ignored
 	// in responses.
 	Jar http.CookieJar
+
+	// MaxErrorBodySize specifies the maximum size of the error response buffer
+	// in the case of a bad hanshake. If zero, a defaut max size buffer of 1024 bytes
+	// is used.
+	MaxErrorBodySize int
 }
 
 // Dial creates a new client connection by calling DialContext with a background context.
@@ -172,8 +177,6 @@ var nilDialer = *DefaultDialer
 // non-nil *http.Response so that callers can handle redirects, authentication,
 // etcetera. The response body may not contain the entire response and does not
 // need to be closed by the application.
-var maxErrorResponseSize = 4096
-
 func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
 	if d == nil {
 		d = &nilDialer
@@ -366,12 +369,12 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 		// Before closing the network connection on return from this
 		// function, slurp up some of the response to aid application
 		// debugging.
-
-		limReader := io.LimitReader(resp.Body, int64(maxErrorResponseSize))
-		buf, err := io.ReadAll(limReader)
-		if err != nil && err != io.EOF {
-			buf = []byte{}
+		bufSize := 1024
+		if d.MaxErrorBodySize > 0 {
+			bufSize = d.MaxErrorBodySize
 		}
+		limReader := io.LimitReader(resp.Body, int64(bufSize))
+		buf, _ := io.ReadAll(limReader)
 		resp.Body = io.NopCloser(bytes.NewReader(buf))
 		return nil, resp, ErrBadHandshake
 	}

--- a/client.go
+++ b/client.go
@@ -173,6 +173,7 @@ var nilDialer = *DefaultDialer
 // etcetera. The response body may not contain the entire response and does not
 // need to be closed by the application.
 var maxErrorResponseSize = 4096
+
 func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader http.Header) (*Conn, *http.Response, error) {
 	if d == nil {
 		d = &nilDialer
@@ -366,7 +367,6 @@ func (d *Dialer) DialContext(ctx context.Context, urlStr string, requestHeader h
 		// function, slurp up some of the response to aid application
 		// debugging.
 
-		// Mon implémentation avec une maxErrorResponseSize
 		limReader := io.LimitReader(resp.Body, int64(maxErrorResponseSize))
 		buf, err := io.ReadAll(limReader)
 		if err != nil && err != io.EOF {

--- a/client_server_test.go
+++ b/client_server_test.go
@@ -573,8 +573,10 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestRespOnBadHandshake(t *testing.T) {
+	// Test Body smaller than maxErrorResponseSize.
 	const expectedStatus = http.StatusGone
 	const expectedBody = "This is the response body."
+	const maxErrorResponseSize = 4096
 
 	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(expectedStatus)
@@ -604,6 +606,76 @@ func TestRespOnBadHandshake(t *testing.T) {
 	if string(p) != expectedBody {
 		t.Errorf("resp.Body=%s, want %s", p, expectedBody)
 	}
+
+	// Test Body larger than maxErrorResponseSize.
+	t.Run("ErrorResponseSizeLimited", func(t *testing.T) {
+		largeBody := make([]byte, maxErrorResponseSize+100)
+		for i := range largeBody {
+			largeBody[i] = 'a'
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusInternalServerError)
+			w.Write(largeBody)
+		}))
+		defer s.Close()
+
+		ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
+		if err == nil {
+			ws.Close()
+			t.Fatalf("Dial: expected error, got nil")
+		}
+
+		if resp == nil {
+			t.Fatalf("resp=nil, err=%v", err)
+		}
+
+		p, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(resp.Body) returned error %v", err)
+		}
+
+		resp.Body.Close()
+
+		if len(p) > maxErrorResponseSize {
+			t.Fatalf("body size=%d, want <= %d", len(p), maxErrorResponseSize)
+		}
+	})
+
+	// Test Body exactly maxErrorResponseSize.
+	t.Run("ErrorResponseSizeExactLimit", func(t *testing.T) {
+		limitedBody := make([]byte, maxErrorResponseSize)
+		for i := range limitedBody {
+			limitedBody[i] = 'a'
+		}
+
+		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusBadGateway)
+			w.Write(limitedBody)
+		}))
+		defer s.Close()
+
+		ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
+		if err == nil {
+			ws.Close()
+			t.Fatalf("Dial: expected error, got nil")
+		}
+
+		if resp == nil {
+			t.Fatalf("resp=nil, err=%v", err)
+		}
+
+		p, err := io.ReadAll(resp.Body)
+		if err != nil {
+			t.Fatalf("ReadAll(resp.Body) returned error %v", err)
+		}
+
+		resp.Body.Close()
+
+		if len(p) != maxErrorResponseSize {
+			t.Fatalf("body size=%d, want %d", len(p), maxErrorResponseSize)
+		}
+	})
 }
 
 type testLogWriter struct {

--- a/client_server_test.go
+++ b/client_server_test.go
@@ -573,109 +573,52 @@ func TestHandshake(t *testing.T) {
 }
 
 func TestRespOnBadHandshake(t *testing.T) {
-	// Test Body smaller than maxErrorResponseSize.
 	const expectedStatus = http.StatusGone
 	const expectedBody = "This is the response body."
 	const maxErrorResponseSize = 4096
-
-	s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(expectedStatus)
-		_, _ = io.WriteString(w, expectedBody)
-	}))
-	defer s.Close()
-
-	ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
-	if err == nil {
-		ws.Close()
-		t.Fatalf("Dial: nil")
+	tests := []struct {
+		name   string
+		body   []byte
+		lenMax int
+	}{
+		{"SmallerThanLimit", []byte(expectedBody), 1024}, // default value when MaxErrorBodySize is not set
+		{"LargerThanLimit", make([]byte, maxErrorResponseSize+100), maxErrorResponseSize},
+		{"ExactLimit", make([]byte, maxErrorResponseSize), maxErrorResponseSize},
 	}
 
-	if resp == nil {
-		t.Fatalf("resp=nil, err=%v", err)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(expectedStatus)
+				_, _ = w.Write(tt.body)
+			}))
+			defer s.Close()
+
+			ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
+			if err == nil {
+				ws.Close()
+				t.Fatalf("Dial: nil")
+			}
+
+			if resp == nil {
+				t.Fatalf("resp=nil, err=%v", err)
+			}
+
+			if resp.StatusCode != expectedStatus {
+				t.Errorf("resp.StatusCode=%d, want %d", resp.StatusCode, expectedStatus)
+			}
+
+			p, err := io.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatalf("ReadFull(resp.Body) returned error %v", err)
+			}
+
+			if len(p) > tt.lenMax {
+				t.Fatalf("body size=%d, want <= %d", len(p), tt.lenMax)
+			}
+		})
+
 	}
-
-	if resp.StatusCode != expectedStatus {
-		t.Errorf("resp.StatusCode=%d, want %d", resp.StatusCode, expectedStatus)
-	}
-
-	p, err := io.ReadAll(resp.Body)
-	if err != nil {
-		t.Fatalf("ReadFull(resp.Body) returned error %v", err)
-	}
-
-	if string(p) != expectedBody {
-		t.Errorf("resp.Body=%s, want %s", p, expectedBody)
-	}
-
-	// Test Body larger than maxErrorResponseSize.
-	t.Run("ErrorResponseSizeLimited", func(t *testing.T) {
-		largeBody := make([]byte, maxErrorResponseSize+100)
-		for i := range largeBody {
-			largeBody[i] = 'a'
-		}
-
-		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusInternalServerError)
-			w.Write(largeBody)
-		}))
-		defer s.Close()
-
-		ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
-		if err == nil {
-			ws.Close()
-			t.Fatalf("Dial: expected error, got nil")
-		}
-
-		if resp == nil {
-			t.Fatalf("resp=nil, err=%v", err)
-		}
-
-		p, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatalf("ReadAll(resp.Body) returned error %v", err)
-		}
-
-		resp.Body.Close()
-
-		if len(p) > maxErrorResponseSize {
-			t.Fatalf("body size=%d, want <= %d", len(p), maxErrorResponseSize)
-		}
-	})
-
-	// Test Body exactly maxErrorResponseSize.
-	t.Run("ErrorResponseSizeExactLimit", func(t *testing.T) {
-		limitedBody := make([]byte, maxErrorResponseSize)
-		for i := range limitedBody {
-			limitedBody[i] = 'a'
-		}
-
-		s := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			w.WriteHeader(http.StatusBadGateway)
-			w.Write(limitedBody)
-		}))
-		defer s.Close()
-
-		ws, resp, err := cstDialer.Dial(makeWsProto(s.URL), nil)
-		if err == nil {
-			ws.Close()
-			t.Fatalf("Dial: expected error, got nil")
-		}
-
-		if resp == nil {
-			t.Fatalf("resp=nil, err=%v", err)
-		}
-
-		p, err := io.ReadAll(resp.Body)
-		if err != nil {
-			t.Fatalf("ReadAll(resp.Body) returned error %v", err)
-		}
-
-		resp.Body.Close()
-
-		if len(p) != maxErrorResponseSize {
-			t.Fatalf("body size=%d, want %d", len(p), maxErrorResponseSize)
-		}
-	})
 }
 
 type testLogWriter struct {


### PR DESCRIPTION
## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [ ] Bug Fix
- [x] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

This PR addresses the buffer size limitation discussed in issue #994 (made by thorrez) by increasing maxErrorResponseSize from 1024 to 4096 bytes when handling non-101 WebSocket upgrade responses.
When a WebSocket upgrade request fails (returns a status code other than 101), the client reads a portion of the error response body to help application debugging. I wanted to increase the buffer size up to 4096 bytes from 1024 bytes. This limit increases allows larger error responses while still protecting against malicious intents (excessively large bodies).
I added 3 cases under the TestRespOnBadHandshake to verify correct behavior : 
- small error ( < 4096 bytes)
- large error ( > 4096 bytes)
- edge case ( = 4096 bytes)

## Related Tickets & Documents

- Related Issue #994 

## Added/updated tests?

- [x] Yes
- [ ] No, and this is why: _please replace this line with details on why tests
      have not been included_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing
