### PR TITLE
fix: avoid incrementing readErrCount for temporary errors and reset o…

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -1009,7 +1009,14 @@ func (c *Conn) NextReader() (messageType int, r io.Reader, err error) {
 		frameType, err := c.advanceFrame()
 		if err != nil {
 			c.readErr = hideTempErr(err)
+			if ne, ok := err.(net.Error); ok && (ne.Temporary() || ne.Timeout()) {
+				// temporary error, report it to the caller
+				return noFrame, nil, c.readErr
+			}
 			break
+		} else {
+			// reset on successful read
+			c.readErrCount = 0
 		}
 
 		if frameType == TextMessage || frameType == BinaryMessage {


### PR DESCRIPTION
### Commit title
fix: avoid incrementing readErrCount for temporary errors and reset on successful read

### Description

- Do not increment `readErrCount` for temporary errors such as timeouts, as they do not indicate actual connection failures.
- Reset `readErrCount` after successful read operations to reflect the true health status of the connection.
- This prevents `readErrCount` from growing due to normal timeout logic and provides a more accurate error state.

## What type of PR is this? (check all applicable)

- [ ] Refactor
- [ ] Feature
- [x] Bug Fix
- [ ] Optimization
- [ ] Documentation Update
- [ ] Go Version Update
- [ ] Dependency Update

## Description

This PR addresses an issue where `readErrCount` was incremented on all errors, including temporary errors such as timeouts. Since timeouts often occur as part of normal connection management, especially when read deadlines are used, counting them as errors could lead to misleading high error counts and unnecessary connection termination or misreporting.

Now, only permanent errors cause `readErrCount` to increase, and a successful read resets this counter, better reflecting the real stability of the connection.

## Related Tickets & Documents

- Related Issue #
- Closes #  <!-- Link the issue if applicable -->

## Added/updated tests?

- [ ] Yes
- [x] No, and this is why: _Please add details if you do not include tests (if the repo policy requires, plan test additions)_
- [ ] I need help with writing tests

## Run verifications and test

- [x] `make verify` is passing
- [x] `make test` is passing

---

**Checklist (before submitting):**
- [x] Read the [Contributing guide](https://github.com/gorilla/.github/blob/main/CONTRIBUTING.md)
- [x] Read the [Code of Conduct](https://github.com/gorilla/.github/blob/main/CODE_OF_CONDUCT.md)
- [x] Provided clear commit messages and code comments.
- [x] Added/updated documentation as needed.
- [x] Requested review from gorilla/pull-request-reviewers.